### PR TITLE
Refactor type registration code

### DIFF
--- a/src/Flecs.NET.Examples/Cpp/Entities/Hierarchy.cs
+++ b/src/Flecs.NET.Examples/Cpp/Entities/Hierarchy.cs
@@ -69,17 +69,17 @@ public struct Moon { }
 // Output:
 // Child of Earth? True
 //
-// ::Sun [Star, Position, (Identifier,Name)]
+// Sun [Star, Position, (Identifier,Name)]
 // (1, 1)
 //
-// ::Sun::Mercury [Position, Planet, (Identifier,Name), (ChildOf,Sun)]
+// Sun.Mercury [Position, Planet, (Identifier,Name), (ChildOf,Sun)]
 // (2, 2)
 //
-// ::Sun::Venus [Position, Planet, (Identifier,Name), (ChildOf,Sun)]
+// Sun.Venus [Position, Planet, (Identifier,Name), (ChildOf,Sun)]
 // (3, 3)
 //
-// ::Sun::Earth [Position, Planet, (Identifier,Name), (ChildOf,Sun)]
+// Sun.Earth [Position, Planet, (Identifier,Name), (ChildOf,Sun)]
 // (4, 4)
 //
-// ::Sun::Earth::Moon [Position, Moon, (Identifier,Name), (ChildOf,Sun.Earth)]
+// Sun.Earth.Moon [Position, Moon, (Identifier,Name), (ChildOf,Sun.Earth)]
 // (4.1, 4.1)

--- a/src/Flecs.NET.Examples/Cpp/Prefabs/Basics.cs
+++ b/src/Flecs.NET.Examples/Cpp/Prefabs/Basics.cs
@@ -56,4 +56,4 @@ public struct Defense
 // Output:
 // Defense: 50
 // Defense after set: 100
-// ::my_spaceship: 100
+// my_spaceship: 100

--- a/src/Flecs.NET.Examples/Cpp/Prefabs/Hierarchy.cs
+++ b/src/Flecs.NET.Examples/Cpp/Prefabs/Hierarchy.cs
@@ -24,5 +24,5 @@ Console.WriteLine($"Instance Cockpit: {instCockpit.Path()}");
 #endif
 
 // Output:
-// Instance Engine: ::my_spaceship::Engine
-// Instance Cockpit: ::my_spaceship::Cockpit
+// Instance Engine: my_spaceship.Engine
+// Instance Cockpit: my_spaceship.Cockpit

--- a/src/Flecs.NET.Examples/Cpp/Prefabs/Slots.cs
+++ b/src/Flecs.NET.Examples/Cpp/Prefabs/Slots.cs
@@ -62,6 +62,6 @@ Console.WriteLine("Instance Seat:    " + instSeat.Path());
 #endif
 
 // Output:
-// Instance Engine:  ::my_spaceship::Engine
-// Instance Cockpit: ::my_spaceship::Cockpit
-// Instance Seat:    ::my_spaceship::Cockpit::PilotSeat
+// Instance Engine:  my_spaceship.Engine
+// Instance Cockpit: my_spaceship.Cockpit
+// Instance Seat:    my_spaceship.Cockpit.PilotSeat

--- a/src/Flecs.NET.Examples/Cpp/Prefabs/TypedPrefabs.cs
+++ b/src/Flecs.NET.Examples/Cpp/Prefabs/TypedPrefabs.cs
@@ -51,6 +51,6 @@ public struct Railgun
 #endif
 
 // Output:
-// Instance Base: ::my_railgun::Base
-// Instance Head: ::my_railgun::Head
-// Instance Beam: ::my_railgun::Beam
+// Instance Base: my_railgun.Base
+// Instance Head: my_railgun.Head
+// Instance Beam: my_railgun.Beam

--- a/src/Flecs.NET.Examples/Cpp/Relationships/EnumRelations.cs
+++ b/src/Flecs.NET.Examples/Cpp/Relationships/EnumRelations.cs
@@ -32,7 +32,7 @@ tile.Add(TileStatus.Occupied);
 // (Tile, Tile.Stone), (TileStatus, TileStatus.Occupied)
 Console.WriteLine(tile.Type().Str());
 
-// Check if the entity has the Tile relationship and the Tile::Stone pair
+// Check if the entity has the Tile relationship and the Tile.Stone pair
 Console.WriteLine(tile.Has<Tile>()); // True
 Console.WriteLine(tile.Has(Tile.Stone)); // True
 
@@ -56,9 +56,9 @@ filter1.Each((Iter it, int i) =>
 });
 
 // Outputs:
-//  ::Tile::Stone
-//  ::Tile::Grass
-//  ::Tile::Sand
+//  Tile.Stone
+//  Tile.Grass
+//  Tile.Sand
 
 // Iterate only occupied tiles
 using Filter filter2 = world.Filter(
@@ -74,8 +74,8 @@ filter2.Each((Iter it, int i) =>
 });
 
 // Outputs:
-//  ::Tile::Stone
-//  ::Tile::Sand
+//  Tile.Stone
+//  Tile.Sand
 
 // Remove any instance of the TileStatus relationship
 tile.Remove<TileStatus>();
@@ -101,8 +101,8 @@ public enum TileStatus
 // True
 // True
 // True
-// ::Tile::Stone
-// ::Tile::Grass
-// ::Tile::Sand
-// ::Tile::Stone
-// ::Tile::Sand
+// Tile.Stone
+// Tile.Grass
+// Tile.Sand
+// Tile.Stone
+// Tile.Sand

--- a/src/Flecs.NET.Examples/Cpp/Relationships/RelationComponent.cs
+++ b/src/Flecs.NET.Examples/Cpp/Relationships/RelationComponent.cs
@@ -80,8 +80,8 @@ public struct MustHave { }
 // requires: 1.21
 // requires: 1.21
 // expires: 0.5
-// ::Requires
-// ::Requires
-// ::Expires
+// Requires
+// Requires
+// Expires
 // 0
 // requires 1.21 gigawatts

--- a/src/Flecs.NET.Examples/Cpp/Rules/Facts.cs
+++ b/src/Flecs.NET.Examples/Cpp/Rules/Facts.cs
@@ -1,0 +1,76 @@
+// This example shows how to use rules for testing facts. A fact is a query that
+// has no variable elements. Consider a regular ECS query like this:
+//   Position, Velocity
+//
+// When written out in full, this query looks like:
+//   Position($This), Velocity($This)
+//
+// "This" is a (builtin) query variable that is unknown before we evaluate the
+// query. Therefore this query does not test a fact, we can't know which values
+// This will assume.
+//
+// An example of a fact-checking query is:
+//   IsA(Cat, Animal)
+//
+// This is a fact: the query has no elements that are unknown before evaluating
+// the query. A rule that checks a fact does not return entities, but will
+// instead return the reasons why a fact is true (if it is true).
+
+// TODO: Finish this
+#if Cpp_Rules_Facts
+
+using Flecs.NET.Core;
+
+using World world = World.Create();
+
+Entity bob = world.Entity("Bob");
+Entity alice = world.Entity("Alice");
+Entity jane = world.Entity("Jane");
+Entity john = world.Entity("John");
+
+bob.Add<Likes>(alice);
+alice.Add<Likes>(bob);
+jane.Add<Likes>(john);
+john.Add<Likes>(jane);
+
+bob.Add<Likes>(john); // bit of drama
+
+// Create a rule that checks if two entities like each other. By itself this
+// rule is not a fact, but we can use it to check facts by populating both
+// of its variables.
+//
+// The equivalent query in the DSL is:
+//  Likes($X, $Y), Likes($Y, $X)
+//
+// Instead of using variables we could have created a rule that referred the
+// entities directly, but then we would have to create a rule for each
+// fact, vs reusing a single rule for multiple facts.
+Rule friends = world.Rule(
+    filter: world.FilterBuilder()
+        .With<Likes>("$Y").Src("$X")
+        .With<Likes>("$X").Src("$Y")
+);
+
+int xVar = friends.FindVar("X");
+int yVar = friends.FindVar("Y");
+
+// Check a few facts
+
+friends.Iter((Iter it) =>
+{
+    Entity x = it.GetVar(xVar);
+    Entity y = it.GetVar(yVar);
+    Console.WriteLine($"{x.Name()} likes {y.Name()}");
+});
+
+friends.Destruct();
+
+public struct Likes { }
+
+#endif
+
+// Output:
+// Alice likes Bob
+// John likes Jane
+// Jane likes John
+// Bob likes Alice

--- a/src/Flecs.NET.Examples/Cpp/Rules/SettingVariables.cs
+++ b/src/Flecs.NET.Examples/Cpp/Rules/SettingVariables.cs
@@ -1,0 +1,17 @@
+// This example extends the component_inheritance example, and shows how
+// we can use a single rule to match units from different players and platoons
+// by setting query variables before we iterate.
+//
+// The units in this example belong to a platoon, with the platoons belonging
+// to a player.
+
+#if Cpp_Rules_SettingVariables
+
+using Flecs.NET.Core;
+
+using World world = World.Create();
+
+
+public struct Likes { }
+
+#endif

--- a/src/Flecs.NET.Tests/CSharp/Utilities/UtilsTests.cs
+++ b/src/Flecs.NET.Tests/CSharp/Utilities/UtilsTests.cs
@@ -1,0 +1,23 @@
+using System.Runtime.InteropServices;
+using Flecs.NET.Utilities;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace Flecs.NET.Tests.CSharp.Utilities
+{
+    public unsafe class UtilsTests
+    {
+        [Fact]
+        private void StringEqual()
+        {
+            byte* s1 = (byte*)Marshal.StringToHGlobalAnsi("Hello");
+            byte* s2 = (byte*)Marshal.StringToHGlobalAnsi("Hello");
+            byte* s3 = (byte*)Marshal.StringToHGlobalAnsi("Hello World");
+            byte* s4 = (byte*)Marshal.StringToHGlobalAnsi("hello world");
+
+            Assert.True(Utils.StringEqual(s1, s2));
+            Assert.False(Utils.StringEqual(s2, s3));
+            Assert.False(Utils.StringEqual(s3, s4));
+        }
+    }
+}

--- a/src/Flecs.NET.Tests/Cpp/EntityTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/EntityTests.cs
@@ -47,7 +47,7 @@ namespace Flecs.NET.Tests.Cpp
             world.SetScope(prev);
 
             Assert.Equal("Bar", child.Name());
-            Assert.Equal("global::Foo.Bar", child.Path());
+            Assert.Equal("Foo.Bar", child.Path());
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Flecs.NET.Tests.Cpp
             Entity entity = new Entity(world, "Foo.Bar");
             Assert.True(entity != 0);
             Assert.Equal("Bar", entity.Name());
-            Assert.Equal("global::Foo.Bar", entity.Path());
+            Assert.Equal("Foo.Bar", entity.Path());
 
             Entity prev = world.SetScope(entity);
 
@@ -68,7 +68,7 @@ namespace Flecs.NET.Tests.Cpp
             world.SetScope(prev);
 
             Assert.Equal("World", child.Name());
-            Assert.Equal("global::Foo.Bar.Hello.World", child.Path());
+            Assert.Equal("Foo.Bar.Hello.World", child.Path());
         }
 
         [Fact]
@@ -1648,7 +1648,7 @@ namespace Flecs.NET.Tests.Cpp
 
             using ScopedWorld scope = world.Scope(parent);
             Entity child = world.Entity("child");
-            Assert.Equal("global::parent.child", child.Path());
+            Assert.Equal("parent.child", child.Path());
         }
 
         [Fact]
@@ -1664,7 +1664,7 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("global::parent.child.grandchild", grandchild.Path());
+            Assert.Equal("parent.child.grandchild", grandchild.Path());
             Assert.Equal("child.grandchild", grandchild.PathFrom(parent));
         }
 
@@ -1680,7 +1680,7 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("global::Parent.child.grandchild", grandchild.Path());
+            Assert.Equal("Parent.child.grandchild", grandchild.Path());
             Assert.Equal("child.grandchild", grandchild.PathFrom<Parent>());
         }
 
@@ -1708,7 +1708,7 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("global::parent.child.grandchild", grandchild.Path());
+            Assert.Equal("parent.child.grandchild", grandchild.Path());
             Assert.Equal("child_grandchild", grandchild.PathFrom(parent, "_"));
         }
 
@@ -1724,7 +1724,7 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("global::Parent.child.grandchild", grandchild.Path());
+            Assert.Equal("Parent.child.grandchild", grandchild.Path());
             Assert.Equal("child_grandchild", grandchild.PathFrom<Parent>("_"));
         }
 
@@ -1737,7 +1737,7 @@ namespace Flecs.NET.Tests.Cpp
             Assert.True(entity != 0);
             Assert.Equal("Bar", entity.Name());
 
-            Assert.Equal("global::Foo.Bar", entity.Path());
+            Assert.Equal("Foo.Bar", entity.Path());
         }
 
         [Fact]
@@ -1855,7 +1855,7 @@ namespace Flecs.NET.Tests.Cpp
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("global::Foo.Bar", e.Path());
+            Assert.Equal("Foo.Bar", e.Path());
         }
 
 
@@ -1878,7 +1878,7 @@ namespace Flecs.NET.Tests.Cpp
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Foo", e.Name());
-            Assert.Equal("global::Parent.Foo", e.Path());
+            Assert.Equal("Parent.Foo", e.Path());
         }
 
         [Fact]
@@ -1900,7 +1900,7 @@ namespace Flecs.NET.Tests.Cpp
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("global::Parent.Foo.Bar", e.Path());
+            Assert.Equal("Parent.Foo.Bar", e.Path());
         }
 
         [Fact]
@@ -1922,11 +1922,11 @@ namespace Flecs.NET.Tests.Cpp
 
             Assert.True(parent.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Parent", parent.Name());
-            Assert.Equal("global::Parent", parent.Path());
+            Assert.Equal("Parent", parent.Path());
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("global::Parent.Foo.Bar", e.Path());
+            Assert.Equal("Parent.Foo.Bar", e.Path());
         }
 
         [Fact]
@@ -1997,7 +1997,7 @@ namespace Flecs.NET.Tests.Cpp
             Assert.True(e.Has(tag));
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Foo", e.Name());
-            Assert.Equal("global::Parent.Foo", e.Path());
+            Assert.Equal("Parent.Foo", e.Path());
         }
 
         [Fact]
@@ -2027,7 +2027,7 @@ namespace Flecs.NET.Tests.Cpp
             Assert.True(e.Has(tag));
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("global::Parent.Foo.Bar", e.Path());
+            Assert.Equal("Parent.Foo.Bar", e.Path());
         }
         //
         // [Fact]
@@ -2990,9 +2990,9 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     world.defer_end();
         //
-        //     Assert.Equal(e1.Path(), "global::e");
-        //     Assert.Equal(f1.Path(), "global::p.f");
-        //     Assert.Equal(g1.Path(), "global::q.g");
+        //     Assert.Equal(e1.Path(), "e");
+        //     Assert.Equal(f1.Path(), "p.f");
+        //     Assert.Equal(g1.Path(), "q.g");
         //
         //     Assert.True(e1 == e2);
         //     Assert.True(f1 == f2);
@@ -3122,9 +3122,9 @@ namespace Flecs.NET.Tests.Cpp
         // void entity_w_root_name() {
         //     using World world = World.Create();
         //
-        //     var e = world.Entity("global::foo");
+        //     var e = world.Entity("foo");
         //     Assert.Equal("Foo", e.Name());
-        //     Assert.Equal(e.Path(), "global::foo");
+        //     Assert.Equal(e.Path(), "foo");
         // }
         //
         // [Fact]
@@ -3133,11 +3133,11 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     var p = world.Entity("parent");
         //     world.set_scope(p);
-        //     var e = world.Entity("global::foo");
+        //     var e = world.Entity("foo");
         //     world.set_scope(0);
         //
         //     Assert.Equal("Foo", e.Name());
-        //     Assert.Equal(e.Path(), "global::foo");
+        //     Assert.Equal(e.Path(), "foo");
         // }
         //
         // struct EntityType { };
@@ -3149,7 +3149,7 @@ namespace Flecs.NET.Tests.Cpp
         //     var e = world.Entity<EntityType>();
         //
         //     Assert.Equal(e.Name(), "EntityType");
-        //     Assert.Equal(e.Path(), "global::EntityType");
+        //     Assert.Equal(e.Path(), "EntityType");
         //     Assert.True(!e.Has<flecs.Component>());
         //
         //     var e_2 = world.Entity<EntityType>();
@@ -3177,8 +3177,8 @@ namespace Flecs.NET.Tests.Cpp
         //     Assert.True(turret_base != 0);
         //     Assert.True(turret_base.Has(EcsChildOf, turret));
         //
-        //     Assert.Equal(turret.Path(), "global::Turret");
-        //     Assert.Equal(turret_base.Path(), "global::Turret.Base");
+        //     Assert.Equal(turret.Path(), "Turret");
+        //     Assert.Equal(turret_base.Path(), "Turret.Base");
         //
         //     Assert.Equal(turret.symbol(), "Turret");
         //     Assert.Equal(turret_base.symbol(), "Turret.Base");
@@ -3196,10 +3196,10 @@ namespace Flecs.NET.Tests.Cpp
         //     Assert.True(railgun_head.Has(EcsChildOf, railgun));
         //     Assert.True(railgun_beam.Has(EcsChildOf, railgun));
         //
-        //     Assert.Equal(railgun.Path(), "global::Railgun");
-        //     Assert.Equal(railgun_base.Path(), "global::Railgun.Base");
-        //     Assert.Equal(railgun_head.Path(), "global::Railgun.Head");
-        //     Assert.Equal(railgun_beam.Path(), "global::Railgun.Beam");
+        //     Assert.Equal(railgun.Path(), "Railgun");
+        //     Assert.Equal(railgun_base.Path(), "Railgun.Base");
+        //     Assert.Equal(railgun_head.Path(), "Railgun.Head");
+        //     Assert.Equal(railgun_beam.Path(), "Railgun.Beam");
         //
         //     Assert.Equal(railgun.symbol(), "Railgun");
         //     Assert.Equal(railgun_head.symbol(), "Railgun.Head");
@@ -3219,8 +3219,8 @@ namespace Flecs.NET.Tests.Cpp
         //     Assert.True(turret_base != 0);
         //     Assert.True(turret_base.Has(EcsChildOf, turret));
         //
-        //     Assert.Equal(turret.Path(), "global::Turret");
-        //     Assert.Equal(turret_base.Path(), "global::Turret.Base");
+        //     Assert.Equal(turret.Path(), "Turret");
+        //     Assert.Equal(turret_base.Path(), "Turret.Base");
         //
         //     Assert.Equal(turret.symbol(), "Turret");
         //     Assert.Equal(turret_base.symbol(), "Base");
@@ -3265,7 +3265,7 @@ namespace Flecs.NET.Tests.Cpp
         //     var p = world.Entity<Parent>();
         //
         //     Assert.Equal(e.Name(), "EntityType");
-        //     Assert.Equal(e.Path(), "global::Parent.EntityType");
+        //     Assert.Equal(e.Path(), "Parent.EntityType");
         //     Assert.True(e.Has(EcsChildOf, p));
         //     Assert.True(!e.Has<flecs.Component>());
         //

--- a/src/Flecs.NET.Tests/Cpp/EntityTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/EntityTests.cs
@@ -47,7 +47,7 @@ namespace Flecs.NET.Tests.Cpp
             world.SetScope(prev);
 
             Assert.Equal("Bar", child.Name());
-            Assert.Equal("::Foo::Bar", child.Path());
+            Assert.Equal("global::Foo.Bar", child.Path());
         }
 
         [Fact]
@@ -55,20 +55,20 @@ namespace Flecs.NET.Tests.Cpp
         {
             using World world = World.Create();
 
-            Entity entity = new Entity(world, "Foo::Bar");
+            Entity entity = new Entity(world, "Foo.Bar");
             Assert.True(entity != 0);
             Assert.Equal("Bar", entity.Name());
-            Assert.Equal("::Foo::Bar", entity.Path());
+            Assert.Equal("global::Foo.Bar", entity.Path());
 
             Entity prev = world.SetScope(entity);
 
-            Entity child = world.Entity("Hello::World");
+            Entity child = world.Entity("Hello.World");
             Assert.True(child != 0);
 
             world.SetScope(prev);
 
             Assert.Equal("World", child.Name());
-            Assert.Equal("::Foo::Bar::Hello::World", child.Path());
+            Assert.Equal("global::Foo.Bar.Hello.World", child.Path());
         }
 
         [Fact]
@@ -1364,7 +1364,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     Entity e = world.Entity()
         //         .Set<Pod>({10});
-        //     Assert.Equal(Pod::copy_invoked, 0);
+        //     Assert.Equal(Pod.copy_invoked, 0);
         //
         //     Assert.True(e.Has<Pod>());
         //     const Pod *p = e.GetPtr<Pod>();
@@ -1380,7 +1380,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     Entity e = world.Entity()
         //         .Set<Pod>(val);
-        //     Assert.Equal(Pod::copy_invoked, 1);
+        //     Assert.Equal(Pod.copy_invoked, 1);
         //
         //     Assert.True(e.Has<Pod>());
         //     const Pod *p = e.GetPtr<Pod>();
@@ -1648,7 +1648,7 @@ namespace Flecs.NET.Tests.Cpp
 
             using ScopedWorld scope = world.Scope(parent);
             Entity child = world.Entity("child");
-            Assert.Equal("::parent::child", child.Path());
+            Assert.Equal("global::parent.child", child.Path());
         }
 
         [Fact]
@@ -1664,8 +1664,8 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("::parent::child::grandchild", grandchild.Path());
-            Assert.Equal("child::grandchild", grandchild.PathFrom(parent));
+            Assert.Equal("global::parent.child.grandchild", grandchild.Path());
+            Assert.Equal("child.grandchild", grandchild.PathFrom(parent));
         }
 
         [Fact]
@@ -1680,8 +1680,8 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("::Parent::child::grandchild", grandchild.Path());
-            Assert.Equal("child::grandchild", grandchild.PathFrom<Parent>());
+            Assert.Equal("global::Parent.child.grandchild", grandchild.Path());
+            Assert.Equal("child.grandchild", grandchild.PathFrom<Parent>());
         }
 
         [Fact]
@@ -1708,7 +1708,7 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("::parent::child::grandchild", grandchild.Path());
+            Assert.Equal("global::parent.child.grandchild", grandchild.Path());
             Assert.Equal("child_grandchild", grandchild.PathFrom(parent, "_"));
         }
 
@@ -1724,7 +1724,7 @@ namespace Flecs.NET.Tests.Cpp
             using ScopedWorld childScope = world.Scope(child);
             Entity grandchild = world.Entity("grandchild");
 
-            Assert.Equal("::Parent::child::grandchild", grandchild.Path());
+            Assert.Equal("global::Parent.child.grandchild", grandchild.Path());
             Assert.Equal("child_grandchild", grandchild.PathFrom<Parent>("_"));
         }
 
@@ -1733,11 +1733,11 @@ namespace Flecs.NET.Tests.Cpp
         {
             using World world = World.Create();
 
-            Entity entity = new Entity(world, "Foo::Bar");
+            Entity entity = new Entity(world, "Foo.Bar");
             Assert.True(entity != 0);
             Assert.Equal("Bar", entity.Name());
 
-            Assert.Equal("::Foo::Bar", entity.Path());
+            Assert.Equal("global::Foo.Bar", entity.Path());
         }
 
         [Fact]
@@ -1796,7 +1796,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         //         auto q = world.query_builder<>().term(Tag).build();
         //
-        //     q.each([&](flecs::entity e) {
+        //     q.each([&](flecs.entity e) {
         //         test_assert(e.has(Tag));
         //
         //         test_bool(e.get([&](const Self& s){
@@ -1849,13 +1849,13 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Defer(() =>
             {
-                e = world.Entity("Foo::Bar");
+                e = world.Entity("Foo.Bar");
                 Assert.True(e != 0);
             });
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("::Foo::Bar", e.Path());
+            Assert.Equal("global::Foo.Bar", e.Path());
         }
 
 
@@ -1878,7 +1878,7 @@ namespace Flecs.NET.Tests.Cpp
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Foo", e.Name());
-            Assert.Equal("::Parent::Foo", e.Path());
+            Assert.Equal("global::Parent.Foo", e.Path());
         }
 
         [Fact]
@@ -1893,14 +1893,14 @@ namespace Flecs.NET.Tests.Cpp
             {
                 parent.Scope(() =>
                 {
-                    e = world.Entity("Foo::Bar");
+                    e = world.Entity("Foo.Bar");
                     Assert.True(e != 0);
                 });
             });
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("::Parent::Foo::Bar", e.Path());
+            Assert.Equal("global::Parent.Foo.Bar", e.Path());
         }
 
         [Fact]
@@ -1915,18 +1915,18 @@ namespace Flecs.NET.Tests.Cpp
             {
                 parent = world.Entity("Parent").Scope(() =>
                 {
-                    e = world.Entity("Foo::Bar");
+                    e = world.Entity("Foo.Bar");
                     Assert.True(e != 0);
                 });
             });
 
             Assert.True(parent.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Parent", parent.Name());
-            Assert.Equal("::Parent", parent.Path());
+            Assert.Equal("global::Parent", parent.Path());
 
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("::Parent::Foo::Bar", e.Path());
+            Assert.Equal("global::Parent.Foo.Bar", e.Path());
         }
 
         [Fact]
@@ -1997,7 +1997,7 @@ namespace Flecs.NET.Tests.Cpp
             Assert.True(e.Has(tag));
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Foo", e.Name());
-            Assert.Equal("::Parent::Foo", e.Path());
+            Assert.Equal("global::Parent.Foo", e.Path());
         }
 
         [Fact]
@@ -2015,7 +2015,7 @@ namespace Flecs.NET.Tests.Cpp
                 {
                     parent.Scope(() =>
                     {
-                        e = world.Entity("Foo::Bar");
+                        e = world.Entity("Foo.Bar");
                         Assert.True(e != 0);
                         Assert.True(!e.Has(tag));
                     });
@@ -2027,7 +2027,7 @@ namespace Flecs.NET.Tests.Cpp
             Assert.True(e.Has(tag));
             Assert.True(e.Has<EcsIdentifier>(EcsName));
             Assert.Equal("Bar", e.Name());
-            Assert.Equal("::Parent::Foo::Bar", e.Path());
+            Assert.Equal("global::Parent.Foo.Bar", e.Path());
         }
         //
         // [Fact]
@@ -2188,7 +2188,7 @@ namespace Flecs.NET.Tests.Cpp
         //             world.Entity("C");
         //         });
         //
-        //     var C = world.Lookup("P::C");
+        //     var C = world.Lookup("P.C");
         //     Assert.True(C != 0);
         // }
         //
@@ -2202,7 +2202,7 @@ namespace Flecs.NET.Tests.Cpp
         //         })
         //         .Set(new Position() { X = 10, Y = 20 });
         //
-        //     var C = world.Lookup("P::C");
+        //     var C = world.Lookup("P.C");
         //     Assert.True(C != 0);
         // }
         //
@@ -2243,7 +2243,7 @@ namespace Flecs.NET.Tests.Cpp
         // void role_id_str() {
         //     using World world = World.Create();
         //
-        //     Id id = flecs::id(ecs, ECS_OVERRIDE | world.Entity("Foo"));
+        //     Id id = flecs.id(ecs, ECS_OVERRIDE | world.Entity("Foo"));
         //
         //     Assert.Equal("OVERRIDE|Foo", id.str());
         // }
@@ -2252,7 +2252,7 @@ namespace Flecs.NET.Tests.Cpp
         // void id_str_from_entity_view() {
         //     using World world = World.Create();
         //
-        //     flecs::entity_view id = world.Entity("Foo");
+        //     flecs.entity_view id = world.Entity("Foo");
         //
         //     Assert.Equal("Foo", id.str());
         // }
@@ -2268,7 +2268,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         // [Fact]
         // void null_entity() {
-        //     Entity e = flecs::entity::null();
+        //     Entity e = flecs.entity.null();
         //     Assert.True(e.id() == 0);
         // }
         //
@@ -2276,14 +2276,14 @@ namespace Flecs.NET.Tests.Cpp
         // void null_entity_w_world() {
         //     using World world = World.Create();
         //
-        //     Entity e = flecs::entity::null(ecs);
+        //     Entity e = flecs.entity.null(ecs);
         //     Assert.True(e.id() == 0);
         //     Assert.True(e.world().c_ptr() == world.c_ptr());
         // }
         //
         // [Fact]
         // void null_entity_w_0() {
-        //     Entity e = flecs::entity(static_cast<ulong>(0));
+        //     Entity e = flecs.entity(static_cast<ulong>(0));
         //     Assert.True(e.id() == 0);
         //     Assert.True(e.world().c_ptr() == null);
         // }
@@ -2292,14 +2292,14 @@ namespace Flecs.NET.Tests.Cpp
         // void null_entity_w_world_w_0() {
         //     using World world = World.Create();
         //
-        //     Entity e = flecs::entity::null(ecs);
+        //     Entity e = flecs.entity.null(ecs);
         //     Assert.True(e.id() == 0);
         //     Assert.True(e.world().c_ptr() == world.c_ptr());
         // }
         //
         // [Fact]
         // void entity_view_null_entity() {
-        //     flecs::entity_view e = flecs::entity::null();
+        //     flecs.entity_view e = flecs.entity.null();
         //     Assert.True(e.id() == 0);
         // }
         //
@@ -2307,14 +2307,14 @@ namespace Flecs.NET.Tests.Cpp
         // void entity_view_null_entity_w_world() {
         //     using World world = World.Create();
         //
-        //     flecs::entity_view e = flecs::entity::null(ecs);
+        //     flecs.entity_view e = flecs.entity.null(ecs);
         //     Assert.True(e.id() == 0);
         //     Assert.True(e.world().c_ptr() == world.c_ptr());
         // }
         //
         // [Fact]
         // void entity_view_null_entity_w_0() {
-        //     flecs::entity_view e = flecs::entity(static_cast<ulong>(0));
+        //     flecs.entity_view e = flecs.entity(static_cast<ulong>(0));
         //     Assert.True(e.id() == 0);
         //     Assert.True(e.world().c_ptr() == null);
         // }
@@ -2323,7 +2323,7 @@ namespace Flecs.NET.Tests.Cpp
         // void entity_view_null_entity_w_world_w_0() {
         //     using World world = World.Create();
         //
-        //     flecs::entity_view e = flecs::entity::null(ecs);
+        //     flecs.entity_view e = flecs.entity.null(ecs);
         //     Assert.True(e.id() == 0);
         //     Assert.True(e.world().c_ptr() == world.c_ptr());
         // }
@@ -2337,9 +2337,9 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     var p0 = e1;
         //     var p1 = world.pair(e1, e2);
-        //     var p2 = world.pair(e1, flecs::Wildcard);
-        //     var p3 = world.pair(flecs::Wildcard, e2);
-        //     var p4 = world.pair(flecs::Wildcard, flecs::Wildcard);
+        //     var p2 = world.pair(e1, flecs.Wildcard);
+        //     var p3 = world.pair(flecs.Wildcard, e2);
+        //     var p4 = world.pair(flecs.Wildcard, flecs.Wildcard);
         //
         //     test_bool(e1.is_wildcard(), false);
         //     test_bool(e2.is_wildcard(), false);
@@ -2413,10 +2413,10 @@ namespace Flecs.NET.Tests.Cpp
         // void has_id() {
         //     using World world = World.Create();
         //
-        //     flecs::id id_1 = world.Entity();
+        //     flecs.id id_1 = world.Entity();
         //     Assert.True(id_1 != 0);
         //
-        //     flecs::id id_2 = world.Entity();
+        //     flecs.id id_2 = world.Entity();
         //     Assert.True(id_2 != 0);
         //
         //     Entity e = world.Entity()
@@ -2431,13 +2431,13 @@ namespace Flecs.NET.Tests.Cpp
         // void has_pair_id() {
         //     using World world = World.Create();
         //
-        //     flecs::id id_1 = world.Entity();
+        //     flecs.id id_1 = world.Entity();
         //     Assert.True(id_1 != 0);
         //
-        //     flecs::id id_2 = world.Entity();
+        //     flecs.id id_2 = world.Entity();
         //     Assert.True(id_2 != 0);
         //
-        //     flecs::id id_3 = world.Entity();
+        //     flecs.id id_3 = world.Entity();
         //     Assert.True(id_3 != 0);
         //
         //     Entity e = world.Entity()
@@ -2454,10 +2454,10 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     struct Rel { };
         //
-        //     flecs::id id_2 = world.Entity();
+        //     flecs.id id_2 = world.Entity();
         //     Assert.True(id_2 != 0);
         //
-        //     flecs::id id_3 = world.Entity();
+        //     flecs.id id_3 = world.Entity();
         //     Assert.True(id_3 != 0);
         //
         //     Entity e = world.Entity()
@@ -2481,25 +2481,25 @@ namespace Flecs.NET.Tests.Cpp
         //     Assert.True(e1 != 0);
         //     Assert.True(e2 != 0);
         //
-        //     test_bool(e1.Has(flecs::Wildcard), true);
-        //     test_bool(e2.Has(flecs::Wildcard), false);
+        //     test_bool(e1.Has(flecs.Wildcard), true);
+        //     test_bool(e2.Has(flecs.Wildcard), false);
         // }
         //
         // [Fact]
         // void has_wildcard_pair_id() {
         //     using World world = World.Create();
         //
-        //     flecs::id rel = world.Entity();
+        //     flecs.id rel = world.Entity();
         //     Assert.True(rel != 0);
         //
-        //     flecs::id obj = world.Entity();
+        //     flecs.id obj = world.Entity();
         //     Assert.True(obj != 0);
         //
-        //     flecs::id obj_2 = world.Entity();
+        //     flecs.id obj_2 = world.Entity();
         //     Assert.True(obj_2 != 0);
         //
-        //     flecs::id w1 = world.id(rel, flecs::Wildcard);
-        //     flecs::id w2 = world.id(flecs::Wildcard, obj);
+        //     flecs.id w1 = world.id(rel, flecs.Wildcard);
+        //     flecs.id w2 = world.id(flecs.Wildcard, obj);
         //
         //     var e1 = world.Entity().Add(rel, obj);
         //     var e2 = world.Entity().Add(rel, obj_2);
@@ -2577,10 +2577,10 @@ namespace Flecs.NET.Tests.Cpp
         // void owns_id() {
         //     using World world = World.Create();
         //
-        //     flecs::id id_1 = world.Entity();
+        //     flecs.id id_1 = world.Entity();
         //     Assert.True(id_1 != 0);
         //
-        //     flecs::id id_2 = world.Entity();
+        //     flecs.id id_2 = world.Entity();
         //     Assert.True(id_2 != 0);
         //
         //     Entity e = world.Entity()
@@ -2595,13 +2595,13 @@ namespace Flecs.NET.Tests.Cpp
         // void owns_pair_id() {
         //     using World world = World.Create();
         //
-        //     flecs::id id_1 = world.Entity();
+        //     flecs.id id_1 = world.Entity();
         //     Assert.True(id_1 != 0);
         //
-        //     flecs::id id_2 = world.Entity();
+        //     flecs.id id_2 = world.Entity();
         //     Assert.True(id_2 != 0);
         //
-        //     flecs::id id_3 = world.Entity();
+        //     flecs.id id_3 = world.Entity();
         //     Assert.True(id_3 != 0);
         //
         //     Entity e = world.Entity()
@@ -2625,25 +2625,25 @@ namespace Flecs.NET.Tests.Cpp
         //     Assert.True(e1 != 0);
         //     Assert.True(e2 != 0);
         //
-        //     test_bool(e1.Owns(flecs::Wildcard), true);
-        //     test_bool(e2.Owns(flecs::Wildcard), false);
+        //     test_bool(e1.Owns(flecs.Wildcard), true);
+        //     test_bool(e2.Owns(flecs.Wildcard), false);
         // }
         //
         // [Fact]
         // void owns_wildcard_pair() {
         //     using World world = World.Create();
         //
-        //     flecs::id rel = world.Entity();
+        //     flecs.id rel = world.Entity();
         //     Assert.True(rel != 0);
         //
-        //     flecs::id obj = world.Entity();
+        //     flecs.id obj = world.Entity();
         //     Assert.True(obj != 0);
         //
-        //     flecs::id obj_2 = world.Entity();
+        //     flecs.id obj_2 = world.Entity();
         //     Assert.True(obj_2 != 0);
         //
-        //     flecs::id w1 = world.id(rel, flecs::Wildcard);
-        //     flecs::id w2 = world.id(flecs::Wildcard, obj);
+        //     flecs.id w1 = world.id(rel, flecs.Wildcard);
+        //     flecs.id w2 = world.id(flecs.Wildcard, obj);
         //
         //     var e1 = world.Entity().Add(rel, obj);
         //     var e2 = world.Entity().Add(rel, obj_2);
@@ -2664,10 +2664,10 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     struct Rel { };
         //
-        //     flecs::id id_2 = world.Entity();
+        //     flecs.id id_2 = world.Entity();
         //     Assert.True(id_2 != 0);
         //
-        //     flecs::id id_3 = world.Entity();
+        //     flecs.id id_3 = world.Entity();
         //     Assert.True(id_3 != 0);
         //
         //     Entity e = world.Entity()
@@ -2685,16 +2685,16 @@ namespace Flecs.NET.Tests.Cpp
         //     Entity e = world.Entity();
         //     Assert.True(e != 0);
         //
-        //     flecs::id id_1 = world.id(e);
+        //     flecs.id id_1 = world.id(e);
         //     Assert.True(id_1 != 0);
         //     Assert.True(id_1 == e);
         //     Assert.True(id_1.world() == ecs);
         //     test_bool(id_1.is_pair(), false);
         //     test_bool(id_1.is_wildcard(), false);
         //
-        //     flecs::id id_2 = world.id(flecs::Wildcard);
+        //     flecs.id id_2 = world.id(flecs.Wildcard);
         //     Assert.True(id_2 != 0);
-        //     Assert.True(id_2 == flecs::Wildcard);
+        //     Assert.True(id_2 == flecs.Wildcard);
         //     Assert.True(id_2.world() == ecs);
         //     test_bool(id_2.is_pair(), false);
         //     test_bool(id_2.is_wildcard(), true);
@@ -2710,7 +2710,7 @@ namespace Flecs.NET.Tests.Cpp
         //     var obj = world.Entity();
         //     Assert.True(obj != 0);
         //
-        //     flecs::id id_1 = world.id(rel, obj);
+        //     flecs.id id_1 = world.id(rel, obj);
         //     Assert.True(id_1 != 0);
         //     Assert.True(id_1.first() == rel);
         //     Assert.True(id_1.second() == obj);
@@ -2718,10 +2718,10 @@ namespace Flecs.NET.Tests.Cpp
         //     test_bool(id_1.is_pair(), true);
         //     test_bool(id_1.is_wildcard(), false);
         //
-        //     flecs::id id_2 = world.id(rel, flecs::Wildcard);
+        //     flecs.id id_2 = world.id(rel, flecs.Wildcard);
         //     Assert.True(id_2 != 0);
         //     Assert.True(id_2.first() == rel);
-        //     Assert.True(id_2.second() == flecs::Wildcard);
+        //     Assert.True(id_2.second() == flecs.Wildcard);
         //     Assert.True(id_2.world() == ecs);
         //     test_bool(id_2.is_pair(), true);
         //     test_bool(id_2.is_wildcard(), true);
@@ -2731,7 +2731,7 @@ namespace Flecs.NET.Tests.Cpp
         // void id_default_from_world() {
         //     using World world = World.Create();
         //
-        //     flecs::id id_default = world.id();
+        //     flecs.id id_default = world.id();
         //     Assert.True(id_default == 0);
         // }
         //
@@ -2794,10 +2794,10 @@ namespace Flecs.NET.Tests.Cpp
         //         .ChildOf(@base)
         //         .slot_of(@base);
         //
-        //     Assert.True(base_child.Has(flecs::SlotOf, @base));
+        //     Assert.True(base_child.Has(flecs.SlotOf, @base));
         //
         //     var inst = world.Entity().is_a(@base);
-        //     Assert.True(inst.Has(base_child, flecs::Wildcard));
+        //     Assert.True(inst.Has(base_child, flecs.Wildcard));
         // }
         //
         // [Fact]
@@ -2811,10 +2811,10 @@ namespace Flecs.NET.Tests.Cpp
         //         .ChildOf(@base)
         //         .slot_of<Parent>();
         //
-        //     Assert.True(base_child.Has(flecs::SlotOf, @base));
+        //     Assert.True(base_child.Has(flecs.SlotOf, @base));
         //
         //     var inst = world.Entity().is_a(@base);
-        //     Assert.True(inst.Has(base_child, flecs::Wildcard));
+        //     Assert.True(inst.Has(base_child, flecs.Wildcard));
         // }
         //
         // [Fact]
@@ -2825,10 +2825,10 @@ namespace Flecs.NET.Tests.Cpp
         //     var base_child = world.Prefab()
         //         .ChildOf(@base).slot();
         //
-        //     Assert.True(base_child.Has(flecs::SlotOf, @base));
+        //     Assert.True(base_child.Has(flecs.SlotOf, @base));
         //
         //     var inst = world.Entity().is_a(@base);
-        //     Assert.True(inst.Has(base_child, flecs::Wildcard));
+        //     Assert.True(inst.Has(base_child, flecs.Wildcard));
         // }
         //
         // [Fact]
@@ -2916,7 +2916,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     world.readonly_begin();
         //
-        //     flecs::world stage = world.get_stage(0);
+        //     flecs.world stage = world.get_stage(0);
         //
         //     bool invoked = false;
         //     e.mut(stage).Get([&](const Position& p) {
@@ -2936,11 +2936,11 @@ namespace Flecs.NET.Tests.Cpp
         //     Entity e1;
         //     Entity e2 = {};
         //
-        //     flecs::entity_view e3;
-        //     flecs::entity_view e4 = {};
+        //     flecs.entity_view e3;
+        //     flecs.entity_view e4 = {};
         //
-        //     flecs::id id1;
-        //     flecs::id id2 = {};
+        //     flecs.id id1;
+        //     flecs.id id2 = {};
         //
         //     e1 = world.Entity();
         //     e2 = world.Entity();
@@ -2982,17 +2982,17 @@ namespace Flecs.NET.Tests.Cpp
         //     var e1 = world.Entity("e");
         //     var e2 = world.Entity("e");
         //
-        //     var f1 = world.Entity("p::f");
-        //     var f2 = world.Entity("p::f");
+        //     var f1 = world.Entity("p.f");
+        //     var f2 = world.Entity("p.f");
         //
         //     var g1 = world.Scope(world.Entity("q")).Entity("g");
         //     var g2 = world.Scope(world.Entity("q")).Entity("g");
         //
         //     world.defer_end();
         //
-        //     Assert.Equal(e1.Path(), "::e");
-        //     Assert.Equal(f1.Path(), "::p::f");
-        //     Assert.Equal(g1.Path(), "::q::g");
+        //     Assert.Equal(e1.Path(), "global::e");
+        //     Assert.Equal(f1.Path(), "global::p.f");
+        //     Assert.Equal(g1.Path(), "global::q.g");
         //
         //     Assert.True(e1 == e2);
         //     Assert.True(f1 == f2);
@@ -3122,9 +3122,9 @@ namespace Flecs.NET.Tests.Cpp
         // void entity_w_root_name() {
         //     using World world = World.Create();
         //
-        //     var e = world.Entity("::foo");
+        //     var e = world.Entity("global::foo");
         //     Assert.Equal("Foo", e.Name());
-        //     Assert.Equal(e.Path(), "::foo");
+        //     Assert.Equal(e.Path(), "global::foo");
         // }
         //
         // [Fact]
@@ -3133,11 +3133,11 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     var p = world.Entity("parent");
         //     world.set_scope(p);
-        //     var e = world.Entity("::foo");
+        //     var e = world.Entity("global::foo");
         //     world.set_scope(0);
         //
         //     Assert.Equal("Foo", e.Name());
-        //     Assert.Equal(e.Path(), "::foo");
+        //     Assert.Equal(e.Path(), "global::foo");
         // }
         //
         // struct EntityType { };
@@ -3149,8 +3149,8 @@ namespace Flecs.NET.Tests.Cpp
         //     var e = world.Entity<EntityType>();
         //
         //     Assert.Equal(e.Name(), "EntityType");
-        //     Assert.Equal(e.Path(), "::EntityType");
-        //     Assert.True(!e.Has<flecs::Component>());
+        //     Assert.Equal(e.Path(), "global::EntityType");
+        //     Assert.True(!e.Has<flecs.Component>());
         //
         //     var e_2 = world.Entity<EntityType>();
         //     Assert.True(e == e_2);
@@ -3171,22 +3171,22 @@ namespace Flecs.NET.Tests.Cpp
         //     using World world = World.Create();
         //
         //     var turret = world.prefab<Turret>();
-        //         var turret_base = world.prefab<Turret::Base>();
+        //         var turret_base = world.prefab<Turret.Base>();
         //
         //     Assert.True(turret != 0);
         //     Assert.True(turret_base != 0);
         //     Assert.True(turret_base.Has(EcsChildOf, turret));
         //
-        //     Assert.Equal(turret.Path(), "::Turret");
-        //     Assert.Equal(turret_base.Path(), "::Turret::Base");
+        //     Assert.Equal(turret.Path(), "global::Turret");
+        //     Assert.Equal(turret_base.Path(), "global::Turret.Base");
         //
         //     Assert.Equal(turret.symbol(), "Turret");
         //     Assert.Equal(turret_base.symbol(), "Turret.Base");
         //
         //     var railgun = world.prefab<Railgun>().is_a<Turret>();
         //         var railgun_base = railgun.Lookup("Base");
-        //         var railgun_head = world.prefab<Railgun::Head>();
-        //         var railgun_beam = world.prefab<Railgun::Beam>();
+        //         var railgun_head = world.prefab<Railgun.Head>();
+        //         var railgun_beam = world.prefab<Railgun.Beam>();
         //
         //     Assert.True(railgun != 0);
         //     Assert.True(railgun_base != 0);
@@ -3196,10 +3196,10 @@ namespace Flecs.NET.Tests.Cpp
         //     Assert.True(railgun_head.Has(EcsChildOf, railgun));
         //     Assert.True(railgun_beam.Has(EcsChildOf, railgun));
         //
-        //     Assert.Equal(railgun.Path(), "::Railgun");
-        //     Assert.Equal(railgun_base.Path(), "::Railgun::Base");
-        //     Assert.Equal(railgun_head.Path(), "::Railgun::Head");
-        //     Assert.Equal(railgun_beam.Path(), "::Railgun::Beam");
+        //     Assert.Equal(railgun.Path(), "global::Railgun");
+        //     Assert.Equal(railgun_base.Path(), "global::Railgun.Base");
+        //     Assert.Equal(railgun_head.Path(), "global::Railgun.Head");
+        //     Assert.Equal(railgun_beam.Path(), "global::Railgun.Beam");
         //
         //     Assert.Equal(railgun.symbol(), "Railgun");
         //     Assert.Equal(railgun_head.symbol(), "Railgun.Head");
@@ -3219,8 +3219,8 @@ namespace Flecs.NET.Tests.Cpp
         //     Assert.True(turret_base != 0);
         //     Assert.True(turret_base.Has(EcsChildOf, turret));
         //
-        //     Assert.Equal(turret.Path(), "::Turret");
-        //     Assert.Equal(turret_base.Path(), "::Turret::Base");
+        //     Assert.Equal(turret.Path(), "global::Turret");
+        //     Assert.Equal(turret_base.Path(), "global::Turret.Base");
         //
         //     Assert.Equal(turret.symbol(), "Turret");
         //     Assert.Equal(turret_base.symbol(), "Base");
@@ -3240,12 +3240,12 @@ namespace Flecs.NET.Tests.Cpp
         //     struct Bar {};
         //
         //     var t = world.prefab<Turret>();
-        //     var tb = world.prefab<Turret::Base>().Add<Foo>();
+        //     var tb = world.prefab<Turret.Base>().Add<Foo>();
         //     Assert.True(t != 0);
         //     Assert.True(tb != 0);
         //
         //     var r = world.prefab<Railgun>().is_a<Turret>();
-        //     var rb = world.prefab<Railgun::Base>().Add<Bar>();
+        //     var rb = world.prefab<Railgun.Base>().Add<Bar>();
         //     Assert.True(r != 0);
         //     Assert.True(rb != 0);
         //
@@ -3261,15 +3261,15 @@ namespace Flecs.NET.Tests.Cpp
         // void entity_w_nested_type() {
         //     using World world = World.Create();
         //
-        //     var e = world.Entity<Parent::EntityType>();
+        //     var e = world.Entity<Parent.EntityType>();
         //     var p = world.Entity<Parent>();
         //
         //     Assert.Equal(e.Name(), "EntityType");
-        //     Assert.Equal(e.Path(), "::Parent::EntityType");
+        //     Assert.Equal(e.Path(), "global::Parent.EntityType");
         //     Assert.True(e.Has(EcsChildOf, p));
-        //     Assert.True(!e.Has<flecs::Component>());
+        //     Assert.True(!e.Has<flecs.Component>());
         //
-        //     var e_2 = world.Entity<Parent::EntityType>();
+        //     var e_2 = world.Entity<Parent.EntityType>();
         //     Assert.True(e == e_2);
         // }
         //
@@ -3280,7 +3280,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     using World world = World.Create();
         //
-        //     flecs::to_array({
+        //     flecs.to_array({
         //         world.Entity(),
         //         world.Entity(),
         //         world.Entity()
@@ -3447,7 +3447,7 @@ namespace Flecs.NET.Tests.Cpp
         //     using World world = World.Create();
         //
         //     Entity e = world.Entity();
-        //     var r = world.Entity().Add(flecs::Exclusive);
+        //     var r = world.Entity().Add(flecs.Exclusive);
         //     var o_1 = world.Entity();
         //     var o_2 = world.Entity();
         //
@@ -3469,7 +3469,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     struct First { };
         //
-        //     world.Component<First>().Add(flecs::Exclusive);
+        //     world.Component<First>().Add(flecs.Exclusive);
         //
         //     Entity e = world.Entity();
         //     var o_1 = world.Entity();
@@ -3495,7 +3495,7 @@ namespace Flecs.NET.Tests.Cpp
         //     struct O_1 { };
         //     struct O_2 { };
         //
-        //     world.Component<R>().Add(flecs::Exclusive);
+        //     world.Component<R>().Add(flecs.Exclusive);
         //
         //     Entity e = world.Entity();
         //
@@ -3524,7 +3524,7 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     e.add_if(0, r, 0);
         //     Assert.True(!e.Has(r, o_1));
-        //     Assert.True(!e.Has(r, flecs::Wildcard));
+        //     Assert.True(!e.Has(r, flecs.Wildcard));
         // }
         //
         // [Fact]
@@ -3590,7 +3590,7 @@ namespace Flecs.NET.Tests.Cpp
         //     using World world = World.Create();
         //
         //     int32_t count = 0;
-        //     world.Entity(flecs::This).children([&](flecs::entity) {
+        //     world.Entity(flecs.This).children([&](flecs.entity) {
         //         count ++;
         //     });
         //     Assert.True(count == 0);
@@ -3601,7 +3601,7 @@ namespace Flecs.NET.Tests.Cpp
         //     using World world = World.Create();
         //
         //     int32_t count = 0;
-        //     world.Entity(flecs::Wildcard).children([&](flecs::entity) {
+        //     world.Entity(flecs.Wildcard).children([&](flecs.entity) {
         //         count ++;
         //     });
         //     Assert.True(count == 0);
@@ -3612,7 +3612,7 @@ namespace Flecs.NET.Tests.Cpp
         //     using World world = World.Create();
         //
         //     int32_t count = 0;
-        //     world.Entity(flecs::Any).children([&](flecs::entity) {
+        //     world.Entity(flecs.Any).children([&](flecs.entity) {
         //         count ++;
         //     });
         //     Assert.True(count == 0);
@@ -3685,7 +3685,7 @@ namespace Flecs.NET.Tests.Cpp
         //     using World world = World.Create();
         //
         //     Entity e = world.Entity();
-        //     flecs::entity_view ev = e.view();
+        //     flecs.entity_view ev = e.view();
         //     Assert.True(e == ev);
         // }
         //
@@ -3696,7 +3696,7 @@ namespace Flecs.NET.Tests.Cpp
         //     var stage = world.get_stage(0);
         //
         //     Entity e = stage.Entity();
-        //     flecs::entity_view ev = e.view();
+        //     flecs.entity_view ev = e.view();
         //     Assert.True(e == ev);
         //     Assert.True(e.world() == stage);
         //     Assert.True(ev.world() == world);
@@ -3707,10 +3707,10 @@ namespace Flecs.NET.Tests.Cpp
         {
             using World world = World.Create();
 
-            Entity e = world.Entity("parent::child");
+            Entity e = world.Entity("parent.child");
             e.SetAlias("parent_child");
 
-            Assert.True(e == world.Lookup("parent::child"));
+            Assert.True(e == world.Lookup("parent.child"));
             Assert.True(e == world.Lookup("parent_child"));
         }
         //
@@ -3719,7 +3719,7 @@ namespace Flecs.NET.Tests.Cpp
         //     using World world = World.Create();
         //
         //     world.observer<Position>()
-        //         .event(flecs::OnAdd)
+        //         .event(flecs.OnAdd)
         //         .each([](Entity e, Position&) {
         //             e.emplace<Velocity>(1.0f, 2.0f);
         //         });

--- a/src/Flecs.NET.Tests/Cpp/WorldFactoryTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/WorldFactoryTests.cs
@@ -249,7 +249,7 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Import<MyModule>();
 
-            Entity p = world.Lookup("MyModule::Position");
+            Entity p = world.Lookup("MyModule.Position");
             Assert.True(p.Id != 0);
         }
     }

--- a/src/Flecs.NET.Tests/Flecs.NET.Tests.csproj
+++ b/src/Flecs.NET.Tests/Flecs.NET.Tests.csproj
@@ -7,17 +7,17 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
-    <Import Project="../Flecs.NET.Native/Flecs.NET.Native.targets"/>
+    <Import Project="../Flecs.NET.Native/Flecs.NET.Native.targets" />
 
     <ItemGroup>
-        <ProjectReference Include="..\Flecs.NET\Flecs.NET.csproj"/>
+        <ProjectReference Include="..\Flecs.NET\Flecs.NET.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
-        <PackageReference Include="xunit" Version="2.4.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
-        <PackageReference Include="coverlet.collector" Version="1.2.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Flecs.NET/Core/Alert.cs
+++ b/src/Flecs.NET/Core/Alert.cs
@@ -38,12 +38,11 @@ namespace Flecs.NET.Core
             if (!string.IsNullOrEmpty(name))
             {
                 using NativeString nativeName = (NativeString)name;
-                using NativeString nativeSep = (NativeString)"::";
 
                 ecs_entity_desc_t entityDesc = default;
                 entityDesc.name = nativeName;
-                entityDesc.sep = nativeSep;
-                entityDesc.root_sep = nativeSep;
+                entityDesc.sep = BindingContext.DefaultSeparator;
+                entityDesc.root_sep = BindingContext.DefaultRootSeparator;
                 alertDesc->entity = ecs_entity_init(world, &entityDesc);
             }
 

--- a/src/Flecs.NET/Core/AlertBuilder.cs
+++ b/src/Flecs.NET/Core/AlertBuilder.cs
@@ -201,10 +201,10 @@ namespace Flecs.NET.Core
         public ref AlertBuilder Member<T>(string member, string var = "")
         {
             using NativeString nativeMember = (NativeString)member;
-            using NativeString nativeSep = (NativeString)"::";
 
             ulong id = Type<T>.Id(World);
-            ulong memberId = ecs_lookup_path_w_sep(World, id, nativeMember, nativeSep, nativeSep, Macros.False);
+            ulong memberId = ecs_lookup_path_w_sep(World, id, nativeMember,
+                BindingContext.DefaultSeparator, BindingContext.DefaultRootSeparator, Macros.False);
 
             Var(var);
 

--- a/src/Flecs.NET/Core/BindingContext.cs
+++ b/src/Flecs.NET/Core/BindingContext.cs
@@ -95,7 +95,7 @@ namespace Flecs.NET.Core
         static BindingContext()
         {
             DefaultSeparator = (byte*)Marshal.StringToHGlobalAnsi(".");
-            DefaultRootSeparator = (byte*)Marshal.StringToHGlobalAnsi("global::");
+            DefaultRootSeparator = (byte*)Marshal.StringToHGlobalAnsi("::");
 
 #if !NET5_0_OR_GREATER
             ObserverIterPointer = Marshal.GetFunctionPointerForDelegate(ObserverIterReference);

--- a/src/Flecs.NET/Core/BindingContext.cs
+++ b/src/Flecs.NET/Core/BindingContext.cs
@@ -12,6 +12,11 @@ namespace Flecs.NET.Core
     /// </summary>
     public static unsafe class BindingContext
     {
+        private static readonly BindingContextCleanup _ = new BindingContextCleanup();
+
+        internal static readonly byte* DefaultSeparator;
+        internal static readonly byte* DefaultRootSeparator;
+
 #if NET5_0_OR_GREATER
         internal static readonly IntPtr ObserverIterPointer =
             (IntPtr)(delegate* unmanaged<ecs_iter_t*, void>)&ObserverIter;
@@ -84,10 +89,15 @@ namespace Flecs.NET.Core
         private static readonly Ecs.ContextFree TypeHooksContextFreeReference = TypeHooksContextFree;
 
         private static readonly Action OsApiAbortReference = OsApiAbort;
+#endif
 
         [SuppressMessage("Usage", "CA1810")]
         static BindingContext()
         {
+            DefaultSeparator = (byte*)Marshal.StringToHGlobalAnsi(".");
+            DefaultRootSeparator = (byte*)Marshal.StringToHGlobalAnsi("global::");
+
+#if !NET5_0_OR_GREATER
             ObserverIterPointer = Marshal.GetFunctionPointerForDelegate(ObserverIterReference);
             RoutineIterPointer = Marshal.GetFunctionPointerForDelegate(RoutineIterReference);
 
@@ -105,8 +115,8 @@ namespace Flecs.NET.Core
             TypeHooksContextFreePointer = Marshal.GetFunctionPointerForDelegate(TypeHooksContextFreeReference);
 
             OsApiAbortPointer = Marshal.GetFunctionPointerForDelegate(OsApiAbortReference);
-        }
 #endif
+        }
 
         [UnmanagedCallersOnly]
         private static void ObserverIter(ecs_iter_t* iter)
@@ -364,6 +374,16 @@ namespace Flecs.NET.Core
                 FreeCallback(ref OnSet);
                 FreeCallback(ref OnRemove);
                 FreeCallback(ref ContextFree);
+            }
+        }
+
+        // Free native resources on program exit
+        private class BindingContextCleanup
+        {
+            ~BindingContextCleanup()
+            {
+                Memory.Free(DefaultSeparator);
+                Memory.Free(DefaultRootSeparator);
             }
         }
     }

--- a/src/Flecs.NET/Core/Component.cs
+++ b/src/Flecs.NET/Core/Component.cs
@@ -57,12 +57,14 @@ namespace Flecs.NET.Core
             if (Type<TComponent>.IsRegistered(world))
             {
                 id = Type<TComponent>.IdExplicit(world, name, allowTag, id);
+
                 using NativeString nativeName = (NativeString)name;
-                ecs_cpp_component_validate(
+
+                FlecsInternal.ComponentValidate(
                     world, id, nativeName,
                     nativeSymbolName,
-                    (IntPtr)Type<TComponent>.GetSize(),
-                    (IntPtr)Type<TComponent>.GetAlignment(),
+                    Type<TComponent>.GetSize(),
+                    Type<TComponent>.GetAlignment(),
                     Macros.Bool(implicitName)
                 );
             }
@@ -77,15 +79,18 @@ namespace Flecs.NET.Core
                     {
                         int index = start;
 
-                        while (index != 0 && name[index] != '.')
+                        while (index != 0 && name[index] != '.' && name[index] != ':')
                             index--;
 
-                        if (name[index] == '.')
+                        if (name[index] == '.' || name[index] == ':')
                             lastElem = index;
                     }
                     else
                     {
                         lastElem = name.LastIndexOf('.');
+
+                        if (lastElem == -1)
+                            lastElem = name.LastIndexOf(':');
                     }
 
                     name = name[(lastElem + 1)..];

--- a/src/Flecs.NET/Core/Ecs.cs
+++ b/src/Flecs.NET/Core/Ecs.cs
@@ -1,11 +1,33 @@
 using System;
+using System.Diagnostics;
 using static Flecs.NET.Bindings.Native;
 
 namespace Flecs.NET.Core
 {
     /// <summary>
-    ///     A static class for storing ECS related types, delegates, and methods.
+    ///     A static class for storing ECS related globals.
     /// </summary>
+    public static partial class Ecs
+    {
+    }
+
+    // TODO: Add proper logging
+    // Debug
+    public static partial class Ecs
+    {
+        [Conditional("DEBUG")]
+        internal static void Assert(bool condition, string message)
+        {
+            Debug.Assert(condition, "[Flecs.NET Assertion]: " + message);
+        }
+
+        internal static void Error(string message)
+        {
+            Debug.Fail("[Flecs.NET Error]: " + message);
+        }
+    }
+
+    // Delegates
     public static unsafe partial class Ecs
     {
         /// <summary>

--- a/src/Flecs.NET/Core/Entity.cs
+++ b/src/Flecs.NET/Core/Entity.cs
@@ -77,12 +77,11 @@ namespace Flecs.NET.Core
         public Entity(ecs_world_t* world, string name)
         {
             using NativeString nativeName = (NativeString)name;
-            using NativeString nativeSeparator = (NativeString)"::";
 
             ecs_entity_desc_t desc = default;
             desc.name = nativeName;
-            desc.sep = nativeSeparator;
-            desc.root_sep = nativeSeparator;
+            desc.sep = BindingContext.DefaultSeparator;
+            desc.root_sep = BindingContext.DefaultRootSeparator;
 
             _id = new Id(world, ecs_entity_init(world, &desc));
         }
@@ -138,7 +137,7 @@ namespace Flecs.NET.Core
         /// <param name="sep"></param>
         /// <param name="initSep"></param>
         /// <returns></returns>
-        public string Path(string sep = "::", string initSep = "::")
+        public string Path(string sep = ".", string initSep = "global::")
         {
             return PathFrom(0, sep, initSep);
         }
@@ -150,7 +149,7 @@ namespace Flecs.NET.Core
         /// <param name="sep"></param>
         /// <param name="initSep"></param>
         /// <returns></returns>
-        public string PathFrom(ulong parent, string sep = "::", string initSep = "::")
+        public string PathFrom(ulong parent, string sep = ".", string initSep = "")
         {
             using NativeString nativeSep = (NativeString)sep;
             using NativeString nativeInitSep = (NativeString)initSep;
@@ -165,7 +164,7 @@ namespace Flecs.NET.Core
         /// <param name="initSep"></param>
         /// <typeparam name="TParent"></typeparam>
         /// <returns></returns>
-        public string PathFrom<TParent>(string sep = "::", string initSep = "::")
+        public string PathFrom<TParent>(string sep = ".", string initSep = "")
         {
             return PathFrom(Type<TParent>.Id(World), sep, initSep);
         }
@@ -726,9 +725,9 @@ namespace Flecs.NET.Core
         public Entity Lookup(string path)
         {
             Assert.True(Id != 0, "invalid lookup from null handle");
-            using NativeString nativeSep = (NativeString)"::";
             using NativeString nativePath = (NativeString)path;
-            ulong id = ecs_lookup_path_w_sep(World, Id, nativePath, nativeSep, nativeSep, Macros.False);
+            ulong id = ecs_lookup_path_w_sep(World, Id, nativePath,
+                BindingContext.DefaultSeparator, BindingContext.DefaultRootSeparator, Macros.False);
             return new Entity(World, id);
         }
 

--- a/src/Flecs.NET/Core/Entity.cs
+++ b/src/Flecs.NET/Core/Entity.cs
@@ -137,7 +137,7 @@ namespace Flecs.NET.Core
         /// <param name="sep"></param>
         /// <param name="initSep"></param>
         /// <returns></returns>
-        public string Path(string sep = ".", string initSep = "global::")
+        public string Path(string sep = ".", string initSep = "")
         {
             return PathFrom(0, sep, initSep);
         }

--- a/src/Flecs.NET/Core/Filter.cs
+++ b/src/Flecs.NET/Core/Filter.cs
@@ -48,12 +48,11 @@ namespace Flecs.NET.Core
             if (!string.IsNullOrEmpty(name))
             {
                 using NativeString nativeName = (NativeString)name;
-                using NativeString nativeSep = (NativeString)"::";
 
                 ecs_entity_desc_t entityDesc = default;
                 entityDesc.name = nativeName;
-                entityDesc.sep = nativeSep;
-                entityDesc.root_sep = nativeSep;
+                entityDesc.sep = BindingContext.DefaultSeparator;
+                entityDesc.root_sep = BindingContext.DefaultRootSeparator;
                 filterDesc->entity = ecs_entity_init(world, &entityDesc);
             }
 

--- a/src/Flecs.NET/Core/Macros.cs
+++ b/src/Flecs.NET/Core/Macros.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using static Flecs.NET.Bindings.Native;
 
 namespace Flecs.NET.Core
@@ -57,6 +59,32 @@ namespace Flecs.NET.Core
 #else
             return Unsafe.AsPointer(ref Unsafe.AsRef(obj)) == null;
 #endif
+        }
+
+        /// <summary>
+        ///     Calls the os api free function.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void OsFree(IntPtr data)
+        {
+#if NET5_0_OR_GREATER
+            ((delegate* unmanaged[Cdecl]<IntPtr, void>)ecs_os_api.free_)(data);
+#else
+            Marshal.GetDelegateForFunctionPointer<Ecs.Free>(ecs_os_api.free_)(data);
+#endif
+        }
+
+        /// <summary>
+        ///     Calls the os api free function.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void OsFree(void* data)
+        {
+            OsFree((IntPtr)data);
         }
 
         /// <summary>

--- a/src/Flecs.NET/Core/Observer.cs
+++ b/src/Flecs.NET/Core/Observer.cs
@@ -34,11 +34,11 @@ namespace Flecs.NET.Core
             ref string name)
         {
             using NativeString nativeName = (NativeString)name;
-            using NativeString nativeSep = (NativeString)"::";
 
             ecs_entity_desc_t entityDesc = default;
             entityDesc.name = nativeName;
-            entityDesc.sep = nativeSep;
+            entityDesc.sep = BindingContext.DefaultSeparator;
+            entityDesc.root_sep = BindingContext.DefaultRootSeparator;
 
             BindingContext.ObserverContext* observerContext = Memory.Alloc<BindingContext.ObserverContext>(1);
             observerContext[0] = observerBuilder.ObserverContext;

--- a/src/Flecs.NET/Core/Query.cs
+++ b/src/Flecs.NET/Core/Query.cs
@@ -54,12 +54,11 @@ namespace Flecs.NET.Core
             if (!string.IsNullOrEmpty(name))
             {
                 using NativeString nativeName = (NativeString)name;
-                using NativeString nativeSep = (NativeString)"::";
 
                 ecs_entity_desc_t entityDesc = default;
                 entityDesc.name = nativeName;
-                entityDesc.sep = nativeSep;
-                entityDesc.root_sep = nativeSep;
+                entityDesc.sep = BindingContext.DefaultSeparator;
+                entityDesc.root_sep = BindingContext.DefaultRootSeparator;
                 queryDesc->filter.entity = ecs_entity_init(world, &entityDesc);
             }
 

--- a/src/Flecs.NET/Core/Routine.cs
+++ b/src/Flecs.NET/Core/Routine.cs
@@ -35,11 +35,11 @@ namespace Flecs.NET.Core
             ref string name)
         {
             using NativeString nativeName = (NativeString)name;
-            using NativeString nativeSep = (NativeString)"::";
 
             ecs_entity_desc_t entityDesc = default;
             entityDesc.name = nativeName;
-            entityDesc.sep = nativeSep;
+            entityDesc.sep = BindingContext.DefaultSeparator;
+            entityDesc.root_sep = BindingContext.DefaultRootSeparator;
 
             ulong entity = ecs_entity_init(world, &entityDesc);
             ulong currentPhase = ecs_get_target(world, entity, EcsDependsOn, 0);

--- a/src/Flecs.NET/Core/Rule.cs
+++ b/src/Flecs.NET/Core/Rule.cs
@@ -40,12 +40,11 @@ namespace Flecs.NET.Core
             if (!string.IsNullOrEmpty(name))
             {
                 using NativeString nativeName = (NativeString)name;
-                using NativeString nativeSep = (NativeString)"::";
 
                 ecs_entity_desc_t entityDesc = default;
                 entityDesc.name = nativeName;
-                entityDesc.sep = nativeSep;
-                entityDesc.root_sep = nativeSep;
+                entityDesc.sep = BindingContext.DefaultSeparator;
+                entityDesc.root_sep = BindingContext.DefaultRootSeparator;
                 filterDesc->entity = ecs_entity_init(world, &entityDesc);
             }
 

--- a/src/Flecs.NET/Core/Type.cs
+++ b/src/Flecs.NET/Core/Type.cs
@@ -307,7 +307,8 @@ namespace Flecs.NET.Core
             if (TypeName != null)
                 return TypeName;
 
-            return TypeName = SymbolName ?? GetSymbolName();
+            string symbolName = SymbolName ?? GetSymbolName();
+            return TypeName = "global::" + symbolName;
         }
 
         /// <summary>
@@ -326,8 +327,7 @@ namespace Flecs.NET.Core
                 IsAlias = true;
 
             csName = csName
-                .Replace(nativeClass, string.Empty,
-                    StringComparison.Ordinal) // Types from the bindings don't use namespaces
+                .Replace(nativeClass, string.Empty, StringComparison.Ordinal) // Strip namespace from binding types
                 .Replace('+', '.')
                 .Replace('[', '<')
                 .Replace(']', '>');
@@ -356,7 +356,6 @@ namespace Flecs.NET.Core
 
             stringBuilder.Append(csName.AsSpan(start));
             SymbolName = stringBuilder.ToString();
-
             return SymbolName;
         }
 

--- a/src/Flecs.NET/Core/Type.cs
+++ b/src/Flecs.NET/Core/Type.cs
@@ -308,7 +308,7 @@ namespace Flecs.NET.Core
                 return TypeName;
 
             string symbolName = SymbolName ?? GetSymbolName();
-            return TypeName = "global::" + symbolName;
+            return TypeName = "::" + symbolName;
         }
 
         /// <summary>

--- a/src/Flecs.NET/Core/Type.cs
+++ b/src/Flecs.NET/Core/Type.cs
@@ -174,10 +174,10 @@ namespace Flecs.NET.Core
             using NativeString nativeTypeName = (NativeString)GetTypeName();
             using NativeString nativeSymbolName = (NativeString)symbol;
 
-            RawId = ecs_cpp_component_register_explicit(
+            RawId = FlecsInternal.ComponentRegisterExplicit(
                 world, RawId, id,
                 nativeName, nativeTypeName, nativeSymbolName,
-                (IntPtr)Size, (IntPtr)Alignment,
+                Size, Alignment,
                 Macros.Bool(isComponent), (byte*)existing
             );
 
@@ -307,8 +307,7 @@ namespace Flecs.NET.Core
             if (TypeName != null)
                 return TypeName;
 
-            string symbol = SymbolName ?? GetSymbolName();
-            return TypeName = symbol.Replace(".", "::", StringComparison.Ordinal);
+            return TypeName = SymbolName ?? GetSymbolName();
         }
 
         /// <summary>

--- a/src/Flecs.NET/Core/World.cs
+++ b/src/Flecs.NET/Core/World.cs
@@ -375,9 +375,12 @@ namespace Flecs.NET.Core
         public Entity Lookup(string name)
         {
             using NativeString nativeName = (NativeString)name;
-            using NativeString nativeSep = (NativeString)"::";
 
-            return new Entity(Handle, ecs_lookup_path_w_sep(Handle, 0, nativeName, nativeSep, nativeSep, Macros.True));
+            return new Entity(
+                Handle,
+                ecs_lookup_path_w_sep(Handle, 0, nativeName,
+                    BindingContext.DefaultSeparator, BindingContext.DefaultRootSeparator, Macros.True)
+            );
         }
 
         /// <summary>
@@ -925,9 +928,10 @@ namespace Flecs.NET.Core
         public Entity Use(string name, string alias = "")
         {
             using NativeString nativeName = (NativeString)name;
-            using NativeString nativeSep = (NativeString)"::";
 
-            ulong entity = ecs_lookup_path_w_sep(Handle, 0, nativeName, nativeSep, nativeSep, Macros.True);
+            ulong entity = ecs_lookup_path_w_sep(Handle, 0, nativeName,
+                BindingContext.DefaultSeparator, BindingContext.DefaultRootSeparator, Macros.True);
+
             Assert.True(entity != 0, nameof(ECS_INVALID_PARAMETER));
 
             using NativeString nativeAlias = (NativeString)alias;
@@ -1705,8 +1709,8 @@ namespace Flecs.NET.Core
             if (!string.IsNullOrEmpty(name))
             {
                 using NativeString nativeName = (NativeString)name;
-                using NativeString nativeSep = (NativeString)"::";
-                ecs_add_path_w_sep(Handle, result, 0, nativeName, nativeSep, nativeSep);
+                ecs_add_path_w_sep(Handle, result, 0, nativeName,
+                    BindingContext.DefaultSeparator, BindingContext.DefaultRootSeparator);
             }
 
             ecs_set_scope(Handle, result);

--- a/src/Flecs.NET/Modules/Alerts.cs
+++ b/src/Flecs.NET/Modules/Alerts.cs
@@ -18,10 +18,10 @@ namespace Flecs.NET.Core
             {
                 FlecsAlertsImport(world);
 
-                world.Entity<Alert>("::flecs::alerts::Alert");
-                world.Entity<Info>("::flecs::alerts::Info");
-                world.Entity<Warning>("::flecs::alerts::Warning");
-                world.Entity<Err>("::flecs::alerts::Error");
+                world.Entity<Alert>("global::flecs.alerts.Alert");
+                world.Entity<Info>("global::flecs.alerts.Info");
+                world.Entity<Warning>("global::flecs.alerts.Warning");
+                world.Entity<Err>("global::flecs.alerts.Error");
             }
 
             /// <summary>

--- a/src/Flecs.NET/Modules/Alerts.cs
+++ b/src/Flecs.NET/Modules/Alerts.cs
@@ -18,10 +18,10 @@ namespace Flecs.NET.Core
             {
                 FlecsAlertsImport(world);
 
-                world.Entity<Alert>("global::flecs.alerts.Alert");
-                world.Entity<Info>("global::flecs.alerts.Info");
-                world.Entity<Warning>("global::flecs.alerts.Warning");
-                world.Entity<Err>("global::flecs.alerts.Error");
+                world.Entity<Alert>("::flecs.alerts.Alert");
+                world.Entity<Info>("::flecs.alerts.Info");
+                world.Entity<Warning>("::flecs.alerts.Warning");
+                world.Entity<Err>("::flecs.alerts.Error");
             }
 
             /// <summary>

--- a/src/Flecs.NET/Modules/Meta.cs
+++ b/src/Flecs.NET/Modules/Meta.cs
@@ -27,17 +27,17 @@ namespace Flecs.NET.Core
                 Type<float>.SetSymbolName("f32");
                 Type<double>.SetSymbolName("f64");
 
-                world.Entity<bool>("::flecs::meta::bool");
-                world.Entity<byte>("::flecs::meta::u8");
-                world.Entity<ushort>("::flecs::meta::u16");
-                world.Entity<uint>("::flecs::meta::u32");
-                world.Entity<ulong>("::flecs::meta::u64");
-                world.Entity<sbyte>("::flecs::meta::i8");
-                world.Entity<short>("::flecs::meta::i16");
-                world.Entity<int>("::flecs::meta::i32");
-                world.Entity<long>("::flecs::meta::i64");
-                world.Entity<float>("::flecs::meta::f32");
-                world.Entity<double>("::flecs::meta::f64");
+                world.Entity<bool>("global::flecs.meta.bool");
+                world.Entity<byte>("global::flecs.meta.u8");
+                world.Entity<ushort>("global::flecs.meta.u16");
+                world.Entity<uint>("global::flecs.meta.u32");
+                world.Entity<ulong>("global::flecs.meta.u64");
+                world.Entity<sbyte>("global::flecs.meta.i8");
+                world.Entity<short>("global::flecs.meta.i16");
+                world.Entity<int>("global::flecs.meta.i32");
+                world.Entity<long>("global::flecs.meta.i64");
+                world.Entity<float>("global::flecs.meta.f32");
+                world.Entity<double>("global::flecs.meta.f64");
 
                 // TODO: Add support for string, char and native sized integers
             }

--- a/src/Flecs.NET/Modules/Meta.cs
+++ b/src/Flecs.NET/Modules/Meta.cs
@@ -27,17 +27,17 @@ namespace Flecs.NET.Core
                 Type<float>.SetSymbolName("f32");
                 Type<double>.SetSymbolName("f64");
 
-                world.Entity<bool>("global::flecs.meta.bool");
-                world.Entity<byte>("global::flecs.meta.u8");
-                world.Entity<ushort>("global::flecs.meta.u16");
-                world.Entity<uint>("global::flecs.meta.u32");
-                world.Entity<ulong>("global::flecs.meta.u64");
-                world.Entity<sbyte>("global::flecs.meta.i8");
-                world.Entity<short>("global::flecs.meta.i16");
-                world.Entity<int>("global::flecs.meta.i32");
-                world.Entity<long>("global::flecs.meta.i64");
-                world.Entity<float>("global::flecs.meta.f32");
-                world.Entity<double>("global::flecs.meta.f64");
+                world.Entity<bool>("::flecs.meta.bool");
+                world.Entity<byte>("::flecs.meta.u8");
+                world.Entity<ushort>("::flecs.meta.u16");
+                world.Entity<uint>("::flecs.meta.u32");
+                world.Entity<ulong>("::flecs.meta.u64");
+                world.Entity<sbyte>("::flecs.meta.i8");
+                world.Entity<short>("::flecs.meta.i16");
+                world.Entity<int>("::flecs.meta.i32");
+                world.Entity<long>("::flecs.meta.i64");
+                world.Entity<float>("::flecs.meta.f32");
+                world.Entity<double>("::flecs.meta.f64");
 
                 // TODO: Add support for string, char and native sized integers
             }

--- a/src/Flecs.NET/Modules/Metrics.cs
+++ b/src/Flecs.NET/Modules/Metrics.cs
@@ -19,12 +19,12 @@ namespace Flecs.NET.Core
 
                 FlecsMetricsImport(world);
 
-                world.Entity<Instance>("global::flecs.metrics.Instance");
-                world.Entity<Metric>("global::flecs.metrics.Metric");
-                world.Entity<Counter>("global::flecs.metrics.Metric.Counter");
-                world.Entity<CounterId>("global::flecs.metrics.Metric.CounterId");
-                world.Entity<CounterIncrement>("global::flecs.metrics.Metric.CounterIncrement");
-                world.Entity<Gauge>("global::flecs.metrics.Metric.Gauge");
+                world.Entity<Instance>("::flecs.metrics.Instance");
+                world.Entity<Metric>("::flecs.metrics.Metric");
+                world.Entity<Counter>("::flecs.metrics.Metric.Counter");
+                world.Entity<CounterId>("::flecs.metrics.Metric.CounterId");
+                world.Entity<CounterIncrement>("::flecs.metrics.Metric.CounterIncrement");
+                world.Entity<Gauge>("::flecs.metrics.Metric.Gauge");
             }
 
             /// <summary>

--- a/src/Flecs.NET/Modules/Metrics.cs
+++ b/src/Flecs.NET/Modules/Metrics.cs
@@ -19,12 +19,12 @@ namespace Flecs.NET.Core
 
                 FlecsMetricsImport(world);
 
-                world.Entity<Instance>("::flecs::metrics::Instance");
-                world.Entity<Metric>("::flecs::metrics::Metric");
-                world.Entity<Counter>("::flecs::metrics::Metric::Counter");
-                world.Entity<CounterId>("::flecs::metrics::Metric::CounterId");
-                world.Entity<CounterIncrement>("::flecs::metrics::Metric::CounterIncrement");
-                world.Entity<Gauge>("::flecs::metrics::Metric::Gauge");
+                world.Entity<Instance>("global::flecs.metrics.Instance");
+                world.Entity<Metric>("global::flecs.metrics.Metric");
+                world.Entity<Counter>("global::flecs.metrics.Metric.Counter");
+                world.Entity<CounterId>("global::flecs.metrics.Metric.CounterId");
+                world.Entity<CounterIncrement>("global::flecs.metrics.Metric.CounterIncrement");
+                world.Entity<Gauge>("global::flecs.metrics.Metric.Gauge");
             }
 
             /// <summary>

--- a/src/Flecs.NET/Modules/Units.cs
+++ b/src/Flecs.NET/Modules/Units.cs
@@ -21,135 +21,135 @@ namespace Flecs.NET.Core
 
                 world.Module<Units>();
 
-                world.Entity<Prefixes>("global::flecs.units.prefixes");
+                world.Entity<Prefixes>("::flecs.units.prefixes");
 
-                world.Entity<Yocto>("global::flecs.units.prefixes.Yocto");
-                world.Entity<Zepto>("global::flecs.units.prefixes.Zepto");
-                world.Entity<Atto>("global::flecs.units.prefixes.Atto");
-                world.Entity<Femto>("global::flecs.units.prefixes.Femto");
-                world.Entity<Pico>("global::flecs.units.prefixes.Pico");
-                world.Entity<Nano>("global::flecs.units.prefixes.Nano");
-                world.Entity<Micro>("global::flecs.units.prefixes.Micro");
-                world.Entity<Milli>("global::flecs.units.prefixes.Milli");
-                world.Entity<Centi>("global::flecs.units.prefixes.Centi");
-                world.Entity<Deci>("global::flecs.units.prefixes.Deci");
-                world.Entity<Deca>("global::flecs.units.prefixes.Deca");
-                world.Entity<Hecto>("global::flecs.units.prefixes.Hecto");
-                world.Entity<Kilo>("global::flecs.units.prefixes.Kilo");
-                world.Entity<Mega>("global::flecs.units.prefixes.Mega");
-                world.Entity<Giga>("global::flecs.units.prefixes.Giga");
-                world.Entity<Tera>("global::flecs.units.prefixes.Tera");
-                world.Entity<Peta>("global::flecs.units.prefixes.Peta");
-                world.Entity<Exa>("global::flecs.units.prefixes.Exa");
-                world.Entity<Zetta>("global::flecs.units.prefixes.Zetta");
-                world.Entity<Yotta>("global::flecs.units.prefixes.Yotta");
-                world.Entity<Kibi>("global::flecs.units.prefixes.Kibi");
-                world.Entity<Mebi>("global::flecs.units.prefixes.Mebi");
-                world.Entity<Gibi>("global::flecs.units.prefixes.Gibi");
-                world.Entity<Tebi>("global::flecs.units.prefixes.Tebi");
-                world.Entity<Pebi>("global::flecs.units.prefixes.Pebi");
-                world.Entity<Exbi>("global::flecs.units.prefixes.Exbi");
-                world.Entity<Zebi>("global::flecs.units.prefixes.Zebi");
-                world.Entity<Yobi>("global::flecs.units.prefixes.Yobi");
+                world.Entity<Yocto>("::flecs.units.prefixes.Yocto");
+                world.Entity<Zepto>("::flecs.units.prefixes.Zepto");
+                world.Entity<Atto>("::flecs.units.prefixes.Atto");
+                world.Entity<Femto>("::flecs.units.prefixes.Femto");
+                world.Entity<Pico>("::flecs.units.prefixes.Pico");
+                world.Entity<Nano>("::flecs.units.prefixes.Nano");
+                world.Entity<Micro>("::flecs.units.prefixes.Micro");
+                world.Entity<Milli>("::flecs.units.prefixes.Milli");
+                world.Entity<Centi>("::flecs.units.prefixes.Centi");
+                world.Entity<Deci>("::flecs.units.prefixes.Deci");
+                world.Entity<Deca>("::flecs.units.prefixes.Deca");
+                world.Entity<Hecto>("::flecs.units.prefixes.Hecto");
+                world.Entity<Kilo>("::flecs.units.prefixes.Kilo");
+                world.Entity<Mega>("::flecs.units.prefixes.Mega");
+                world.Entity<Giga>("::flecs.units.prefixes.Giga");
+                world.Entity<Tera>("::flecs.units.prefixes.Tera");
+                world.Entity<Peta>("::flecs.units.prefixes.Peta");
+                world.Entity<Exa>("::flecs.units.prefixes.Exa");
+                world.Entity<Zetta>("::flecs.units.prefixes.Zetta");
+                world.Entity<Yotta>("::flecs.units.prefixes.Yotta");
+                world.Entity<Kibi>("::flecs.units.prefixes.Kibi");
+                world.Entity<Mebi>("::flecs.units.prefixes.Mebi");
+                world.Entity<Gibi>("::flecs.units.prefixes.Gibi");
+                world.Entity<Tebi>("::flecs.units.prefixes.Tebi");
+                world.Entity<Pebi>("::flecs.units.prefixes.Pebi");
+                world.Entity<Exbi>("::flecs.units.prefixes.Exbi");
+                world.Entity<Zebi>("::flecs.units.prefixes.Zebi");
+                world.Entity<Yobi>("::flecs.units.prefixes.Yobi");
 
-                world.Entity<Duration>("global::flecs.units.Duration");
-                world.Entity<Time>("global::flecs.units.Time");
-                world.Entity<Mass>("global::flecs.units.Mass");
-                world.Entity<Force>("global::flecs.units.Force");
-                world.Entity<ElectricCurrent>("global::flecs.units.ElectricCurrent");
-                world.Entity<Amount>("global::flecs.units.Amount");
-                world.Entity<LuminousIntensity>("global::flecs.units.LuminousIntensity");
-                world.Entity<Length>("global::flecs.units.Length");
-                world.Entity<Pressure>("global::flecs.units.Pressure");
-                world.Entity<Speed>("global::flecs.units.Speed");
-                world.Entity<Temperature>("global::flecs.units.Temperature");
-                world.Entity<Data>("global::flecs.units.Data");
-                world.Entity<DataRate>("global::flecs.units.DataRate");
-                world.Entity<Angle>("global::flecs.units.Angle");
-                world.Entity<Frequency>("global::flecs.units.Frequency");
-                world.Entity<Uri>("global::flecs.units.Uri");
+                world.Entity<Duration>("::flecs.units.Duration");
+                world.Entity<Time>("::flecs.units.Time");
+                world.Entity<Mass>("::flecs.units.Mass");
+                world.Entity<Force>("::flecs.units.Force");
+                world.Entity<ElectricCurrent>("::flecs.units.ElectricCurrent");
+                world.Entity<Amount>("::flecs.units.Amount");
+                world.Entity<LuminousIntensity>("::flecs.units.LuminousIntensity");
+                world.Entity<Length>("::flecs.units.Length");
+                world.Entity<Pressure>("::flecs.units.Pressure");
+                world.Entity<Speed>("::flecs.units.Speed");
+                world.Entity<Temperature>("::flecs.units.Temperature");
+                world.Entity<Data>("::flecs.units.Data");
+                world.Entity<DataRate>("::flecs.units.DataRate");
+                world.Entity<Angle>("::flecs.units.Angle");
+                world.Entity<Frequency>("::flecs.units.Frequency");
+                world.Entity<Uri>("::flecs.units.Uri");
 
-                world.Entity<Durations.PicoSeconds>("global::flecs.units.Duration.PicoSeconds");
-                world.Entity<Durations.NanoSeconds>("global::flecs.units.Duration.NanoSeconds");
-                world.Entity<Durations.MicroSeconds>("global::flecs.units.Duration.MicroSeconds");
-                world.Entity<Durations.MilliSeconds>("global::flecs.units.Duration.MilliSeconds");
-                world.Entity<Durations.Seconds>("global::flecs.units.Duration.Seconds");
-                world.Entity<Durations.Minutes>("global::flecs.units.Duration.Minutes");
-                world.Entity<Durations.Hours>("global::flecs.units.Duration.Hours");
-                world.Entity<Durations.Days>("global::flecs.units.Duration.Days");
+                world.Entity<Durations.PicoSeconds>("::flecs.units.Duration.PicoSeconds");
+                world.Entity<Durations.NanoSeconds>("::flecs.units.Duration.NanoSeconds");
+                world.Entity<Durations.MicroSeconds>("::flecs.units.Duration.MicroSeconds");
+                world.Entity<Durations.MilliSeconds>("::flecs.units.Duration.MilliSeconds");
+                world.Entity<Durations.Seconds>("::flecs.units.Duration.Seconds");
+                world.Entity<Durations.Minutes>("::flecs.units.Duration.Minutes");
+                world.Entity<Durations.Hours>("::flecs.units.Duration.Hours");
+                world.Entity<Durations.Days>("::flecs.units.Duration.Days");
 
-                world.Entity<Times.CalenderDate>("global::flecs.units.Time.Date");
+                world.Entity<Times.CalenderDate>("::flecs.units.Time.Date");
 
-                world.Entity<Masses.Grams>("global::flecs.units.Mass.Grams");
-                world.Entity<Masses.KiloGrams>("global::flecs.units.Mass.KiloGrams");
+                world.Entity<Masses.Grams>("::flecs.units.Mass.Grams");
+                world.Entity<Masses.KiloGrams>("::flecs.units.Mass.KiloGrams");
 
-                world.Entity<ElectricCurrents.Ampere>("global::flecs.units.ElectricCurrent.Ampere");
+                world.Entity<ElectricCurrents.Ampere>("::flecs.units.ElectricCurrent.Ampere");
 
-                world.Entity<Amounts.Mole>("global::flecs.units.Amount.Mole");
+                world.Entity<Amounts.Mole>("::flecs.units.Amount.Mole");
 
-                world.Entity<LuminousIntensities.Candela>("global::flecs.units.LuminousIntensity.Candela");
+                world.Entity<LuminousIntensities.Candela>("::flecs.units.LuminousIntensity.Candela");
 
-                world.Entity<Forces.Newton>("global::flecs.units.Force.Newton");
+                world.Entity<Forces.Newton>("::flecs.units.Force.Newton");
 
-                world.Entity<Lengths.Meters>("global::flecs.units.Length.Meters");
-                world.Entity<Lengths.PicoMeters>("global::flecs.units.Length.PicoMeters");
-                world.Entity<Lengths.NanoMeters>("global::flecs.units.Length.NanoMeters");
-                world.Entity<Lengths.MicroMeters>("global::flecs.units.Length.MicroMeters");
-                world.Entity<Lengths.MilliMeters>("global::flecs.units.Length.MilliMeters");
-                world.Entity<Lengths.CentiMeters>("global::flecs.units.Length.CentiMeters");
-                world.Entity<Lengths.KiloMeters>("global::flecs.units.Length.KiloMeters");
-                world.Entity<Lengths.Miles>("global::flecs.units.Length.Miles");
-                world.Entity<Lengths.Pixels>("global::flecs.units.Length.Pixels");
+                world.Entity<Lengths.Meters>("::flecs.units.Length.Meters");
+                world.Entity<Lengths.PicoMeters>("::flecs.units.Length.PicoMeters");
+                world.Entity<Lengths.NanoMeters>("::flecs.units.Length.NanoMeters");
+                world.Entity<Lengths.MicroMeters>("::flecs.units.Length.MicroMeters");
+                world.Entity<Lengths.MilliMeters>("::flecs.units.Length.MilliMeters");
+                world.Entity<Lengths.CentiMeters>("::flecs.units.Length.CentiMeters");
+                world.Entity<Lengths.KiloMeters>("::flecs.units.Length.KiloMeters");
+                world.Entity<Lengths.Miles>("::flecs.units.Length.Miles");
+                world.Entity<Lengths.Pixels>("::flecs.units.Length.Pixels");
 
-                world.Entity<Pressures.Pascal>("global::flecs.units.Pressure.Pascal");
-                world.Entity<Pressures.Bar>("global::flecs.units.Pressure.Bar");
+                world.Entity<Pressures.Pascal>("::flecs.units.Pressure.Pascal");
+                world.Entity<Pressures.Bar>("::flecs.units.Pressure.Bar");
 
-                world.Entity<Speeds.MetersPerSecond>("global::flecs.units.Speed.MetersPerSecond");
-                world.Entity<Speeds.KiloMetersPerSecond>("global::flecs.units.Speed.KiloMetersPerSecond");
-                world.Entity<Speeds.KiloMetersPerHour>("global::flecs.units.Speed.KiloMetersPerHour");
-                world.Entity<Speeds.MilesPerHour>("global::flecs.units.Speed.MilesPerHour");
+                world.Entity<Speeds.MetersPerSecond>("::flecs.units.Speed.MetersPerSecond");
+                world.Entity<Speeds.KiloMetersPerSecond>("::flecs.units.Speed.KiloMetersPerSecond");
+                world.Entity<Speeds.KiloMetersPerHour>("::flecs.units.Speed.KiloMetersPerHour");
+                world.Entity<Speeds.MilesPerHour>("::flecs.units.Speed.MilesPerHour");
 
-                world.Entity<Temperatures.Kelvin>("global::flecs.units.Temperature.Kelvin");
-                world.Entity<Temperatures.Celsius>("global::flecs.units.Temperature.Celsius");
-                world.Entity<Temperatures.Fahrenheit>("global::flecs.units.Temperature.Fahrenheit");
+                world.Entity<Temperatures.Kelvin>("::flecs.units.Temperature.Kelvin");
+                world.Entity<Temperatures.Celsius>("::flecs.units.Temperature.Celsius");
+                world.Entity<Temperatures.Fahrenheit>("::flecs.units.Temperature.Fahrenheit");
 
-                world.Entity<Datas.Bits>("global::flecs.units.Data.Bits");
-                world.Entity<Datas.KiloBits>("global::flecs.units.Data.KiloBits");
-                world.Entity<Datas.MegaBits>("global::flecs.units.Data.MegaBits");
-                world.Entity<Datas.GigaBits>("global::flecs.units.Data.GigaBits");
-                world.Entity<Datas.Bytes>("global::flecs.units.Data.Bytes");
-                world.Entity<Datas.KiloBytes>("global::flecs.units.Data.KiloBytes");
-                world.Entity<Datas.MegaBytes>("global::flecs.units.Data.MegaBytes");
-                world.Entity<Datas.GigaBytes>("global::flecs.units.Data.GigaBytes");
-                world.Entity<Datas.KibiBytes>("global::flecs.units.Data.KibiBytes");
-                world.Entity<Datas.MebiBytes>("global::flecs.units.Data.MebiBytes");
-                world.Entity<Datas.GibiBytes>("global::flecs.units.Data.GibiBytes");
+                world.Entity<Datas.Bits>("::flecs.units.Data.Bits");
+                world.Entity<Datas.KiloBits>("::flecs.units.Data.KiloBits");
+                world.Entity<Datas.MegaBits>("::flecs.units.Data.MegaBits");
+                world.Entity<Datas.GigaBits>("::flecs.units.Data.GigaBits");
+                world.Entity<Datas.Bytes>("::flecs.units.Data.Bytes");
+                world.Entity<Datas.KiloBytes>("::flecs.units.Data.KiloBytes");
+                world.Entity<Datas.MegaBytes>("::flecs.units.Data.MegaBytes");
+                world.Entity<Datas.GigaBytes>("::flecs.units.Data.GigaBytes");
+                world.Entity<Datas.KibiBytes>("::flecs.units.Data.KibiBytes");
+                world.Entity<Datas.MebiBytes>("::flecs.units.Data.MebiBytes");
+                world.Entity<Datas.GibiBytes>("::flecs.units.Data.GibiBytes");
 
-                world.Entity<DataRates.BitsPerSecond>("global::flecs.units.DataRate.BitsPerSecond");
-                world.Entity<DataRates.KiloBitsPerSecond>("global::flecs.units.DataRate.KiloBitsPerSecond");
-                world.Entity<DataRates.MegaBitsPerSecond>("global::flecs.units.DataRate.MegaBitsPerSecond");
-                world.Entity<DataRates.GigaBitsPerSecond>("global::flecs.units.DataRate.GigaBitsPerSecond");
-                world.Entity<DataRates.BytesPerSecond>("global::flecs.units.DataRate.BytesPerSecond");
-                world.Entity<DataRates.KiloBytesPerSecond>("global::flecs.units.DataRate.KiloBytesPerSecond");
-                world.Entity<DataRates.MegaBytesPerSecond>("global::flecs.units.DataRate.MegaBytesPerSecond");
-                world.Entity<DataRates.GigaBytesPerSecond>("global::flecs.units.DataRate.GigaBytesPerSecond");
+                world.Entity<DataRates.BitsPerSecond>("::flecs.units.DataRate.BitsPerSecond");
+                world.Entity<DataRates.KiloBitsPerSecond>("::flecs.units.DataRate.KiloBitsPerSecond");
+                world.Entity<DataRates.MegaBitsPerSecond>("::flecs.units.DataRate.MegaBitsPerSecond");
+                world.Entity<DataRates.GigaBitsPerSecond>("::flecs.units.DataRate.GigaBitsPerSecond");
+                world.Entity<DataRates.BytesPerSecond>("::flecs.units.DataRate.BytesPerSecond");
+                world.Entity<DataRates.KiloBytesPerSecond>("::flecs.units.DataRate.KiloBytesPerSecond");
+                world.Entity<DataRates.MegaBytesPerSecond>("::flecs.units.DataRate.MegaBytesPerSecond");
+                world.Entity<DataRates.GigaBytesPerSecond>("::flecs.units.DataRate.GigaBytesPerSecond");
 
-                world.Entity<Frequencies.Hertz>("global::flecs.units.Frequency.Hertz");
-                world.Entity<Frequencies.KiloHertz>("global::flecs.units.Frequency.KiloHertz");
-                world.Entity<Frequencies.MegaHertz>("global::flecs.units.Frequency.MegaHertz");
-                world.Entity<Frequencies.GigaHertz>("global::flecs.units.Frequency.GigaHertz");
+                world.Entity<Frequencies.Hertz>("::flecs.units.Frequency.Hertz");
+                world.Entity<Frequencies.KiloHertz>("::flecs.units.Frequency.KiloHertz");
+                world.Entity<Frequencies.MegaHertz>("::flecs.units.Frequency.MegaHertz");
+                world.Entity<Frequencies.GigaHertz>("::flecs.units.Frequency.GigaHertz");
 
-                world.Entity<Uris.Hyperlink>("global::flecs.units.Uri.Hyperlink");
-                world.Entity<Uris.Image>("global::flecs.units.Uri.Image");
-                world.Entity<Uris.File>("global::flecs.units.Uri.File");
+                world.Entity<Uris.Hyperlink>("::flecs.units.Uri.Hyperlink");
+                world.Entity<Uris.Image>("::flecs.units.Uri.Image");
+                world.Entity<Uris.File>("::flecs.units.Uri.File");
 
-                world.Entity<Angles.Radians>("global::flecs.units.Angle.Radians");
-                world.Entity<Angles.Degrees>("global::flecs.units.Angle.Degrees");
+                world.Entity<Angles.Radians>("::flecs.units.Angle.Radians");
+                world.Entity<Angles.Degrees>("::flecs.units.Angle.Degrees");
 
-                world.Entity<Percentage>("global::flecs.units.Percentage");
+                world.Entity<Percentage>("::flecs.units.Percentage");
 
-                world.Entity<Bel>("global::flecs.units.Bel");
-                world.Entity<DeciBel>("global::flecs.units.DeciBel");
+                world.Entity<Bel>("::flecs.units.Bel");
+                world.Entity<DeciBel>("::flecs.units.DeciBel");
             }
 
             /// <summary>

--- a/src/Flecs.NET/Modules/Units.cs
+++ b/src/Flecs.NET/Modules/Units.cs
@@ -21,135 +21,135 @@ namespace Flecs.NET.Core
 
                 world.Module<Units>();
 
-                world.Entity<Prefixes>("::flecs::units::prefixes");
+                world.Entity<Prefixes>("global::flecs.units.prefixes");
 
-                world.Entity<Yocto>("::flecs::units::prefixes::Yocto");
-                world.Entity<Zepto>("::flecs::units::prefixes::Zepto");
-                world.Entity<Atto>("::flecs::units::prefixes::Atto");
-                world.Entity<Femto>("::flecs::units::prefixes::Femto");
-                world.Entity<Pico>("::flecs::units::prefixes::Pico");
-                world.Entity<Nano>("::flecs::units::prefixes::Nano");
-                world.Entity<Micro>("::flecs::units::prefixes::Micro");
-                world.Entity<Milli>("::flecs::units::prefixes::Milli");
-                world.Entity<Centi>("::flecs::units::prefixes::Centi");
-                world.Entity<Deci>("::flecs::units::prefixes::Deci");
-                world.Entity<Deca>("::flecs::units::prefixes::Deca");
-                world.Entity<Hecto>("::flecs::units::prefixes::Hecto");
-                world.Entity<Kilo>("::flecs::units::prefixes::Kilo");
-                world.Entity<Mega>("::flecs::units::prefixes::Mega");
-                world.Entity<Giga>("::flecs::units::prefixes::Giga");
-                world.Entity<Tera>("::flecs::units::prefixes::Tera");
-                world.Entity<Peta>("::flecs::units::prefixes::Peta");
-                world.Entity<Exa>("::flecs::units::prefixes::Exa");
-                world.Entity<Zetta>("::flecs::units::prefixes::Zetta");
-                world.Entity<Yotta>("::flecs::units::prefixes::Yotta");
-                world.Entity<Kibi>("::flecs::units::prefixes::Kibi");
-                world.Entity<Mebi>("::flecs::units::prefixes::Mebi");
-                world.Entity<Gibi>("::flecs::units::prefixes::Gibi");
-                world.Entity<Tebi>("::flecs::units::prefixes::Tebi");
-                world.Entity<Pebi>("::flecs::units::prefixes::Pebi");
-                world.Entity<Exbi>("::flecs::units::prefixes::Exbi");
-                world.Entity<Zebi>("::flecs::units::prefixes::Zebi");
-                world.Entity<Yobi>("::flecs::units::prefixes::Yobi");
+                world.Entity<Yocto>("global::flecs.units.prefixes.Yocto");
+                world.Entity<Zepto>("global::flecs.units.prefixes.Zepto");
+                world.Entity<Atto>("global::flecs.units.prefixes.Atto");
+                world.Entity<Femto>("global::flecs.units.prefixes.Femto");
+                world.Entity<Pico>("global::flecs.units.prefixes.Pico");
+                world.Entity<Nano>("global::flecs.units.prefixes.Nano");
+                world.Entity<Micro>("global::flecs.units.prefixes.Micro");
+                world.Entity<Milli>("global::flecs.units.prefixes.Milli");
+                world.Entity<Centi>("global::flecs.units.prefixes.Centi");
+                world.Entity<Deci>("global::flecs.units.prefixes.Deci");
+                world.Entity<Deca>("global::flecs.units.prefixes.Deca");
+                world.Entity<Hecto>("global::flecs.units.prefixes.Hecto");
+                world.Entity<Kilo>("global::flecs.units.prefixes.Kilo");
+                world.Entity<Mega>("global::flecs.units.prefixes.Mega");
+                world.Entity<Giga>("global::flecs.units.prefixes.Giga");
+                world.Entity<Tera>("global::flecs.units.prefixes.Tera");
+                world.Entity<Peta>("global::flecs.units.prefixes.Peta");
+                world.Entity<Exa>("global::flecs.units.prefixes.Exa");
+                world.Entity<Zetta>("global::flecs.units.prefixes.Zetta");
+                world.Entity<Yotta>("global::flecs.units.prefixes.Yotta");
+                world.Entity<Kibi>("global::flecs.units.prefixes.Kibi");
+                world.Entity<Mebi>("global::flecs.units.prefixes.Mebi");
+                world.Entity<Gibi>("global::flecs.units.prefixes.Gibi");
+                world.Entity<Tebi>("global::flecs.units.prefixes.Tebi");
+                world.Entity<Pebi>("global::flecs.units.prefixes.Pebi");
+                world.Entity<Exbi>("global::flecs.units.prefixes.Exbi");
+                world.Entity<Zebi>("global::flecs.units.prefixes.Zebi");
+                world.Entity<Yobi>("global::flecs.units.prefixes.Yobi");
 
-                world.Entity<Duration>("::flecs::units::Duration");
-                world.Entity<Time>("::flecs::units::Time");
-                world.Entity<Mass>("::flecs::units::Mass");
-                world.Entity<Force>("::flecs::units::Force");
-                world.Entity<ElectricCurrent>("::flecs::units::ElectricCurrent");
-                world.Entity<Amount>("::flecs::units::Amount");
-                world.Entity<LuminousIntensity>("::flecs::units::LuminousIntensity");
-                world.Entity<Length>("::flecs::units::Length");
-                world.Entity<Pressure>("::flecs::units::Pressure");
-                world.Entity<Speed>("::flecs::units::Speed");
-                world.Entity<Temperature>("::flecs::units::Temperature");
-                world.Entity<Data>("::flecs::units::Data");
-                world.Entity<DataRate>("::flecs::units::DataRate");
-                world.Entity<Angle>("::flecs::units::Angle");
-                world.Entity<Frequency>("::flecs::units::Frequency");
-                world.Entity<Uri>("::flecs::units::Uri");
+                world.Entity<Duration>("global::flecs.units.Duration");
+                world.Entity<Time>("global::flecs.units.Time");
+                world.Entity<Mass>("global::flecs.units.Mass");
+                world.Entity<Force>("global::flecs.units.Force");
+                world.Entity<ElectricCurrent>("global::flecs.units.ElectricCurrent");
+                world.Entity<Amount>("global::flecs.units.Amount");
+                world.Entity<LuminousIntensity>("global::flecs.units.LuminousIntensity");
+                world.Entity<Length>("global::flecs.units.Length");
+                world.Entity<Pressure>("global::flecs.units.Pressure");
+                world.Entity<Speed>("global::flecs.units.Speed");
+                world.Entity<Temperature>("global::flecs.units.Temperature");
+                world.Entity<Data>("global::flecs.units.Data");
+                world.Entity<DataRate>("global::flecs.units.DataRate");
+                world.Entity<Angle>("global::flecs.units.Angle");
+                world.Entity<Frequency>("global::flecs.units.Frequency");
+                world.Entity<Uri>("global::flecs.units.Uri");
 
-                world.Entity<Durations.PicoSeconds>("::flecs::units::Duration::PicoSeconds");
-                world.Entity<Durations.NanoSeconds>("::flecs::units::Duration::NanoSeconds");
-                world.Entity<Durations.MicroSeconds>("::flecs::units::Duration::MicroSeconds");
-                world.Entity<Durations.MilliSeconds>("::flecs::units::Duration::MilliSeconds");
-                world.Entity<Durations.Seconds>("::flecs::units::Duration::Seconds");
-                world.Entity<Durations.Minutes>("::flecs::units::Duration::Minutes");
-                world.Entity<Durations.Hours>("::flecs::units::Duration::Hours");
-                world.Entity<Durations.Days>("::flecs::units::Duration::Days");
+                world.Entity<Durations.PicoSeconds>("global::flecs.units.Duration.PicoSeconds");
+                world.Entity<Durations.NanoSeconds>("global::flecs.units.Duration.NanoSeconds");
+                world.Entity<Durations.MicroSeconds>("global::flecs.units.Duration.MicroSeconds");
+                world.Entity<Durations.MilliSeconds>("global::flecs.units.Duration.MilliSeconds");
+                world.Entity<Durations.Seconds>("global::flecs.units.Duration.Seconds");
+                world.Entity<Durations.Minutes>("global::flecs.units.Duration.Minutes");
+                world.Entity<Durations.Hours>("global::flecs.units.Duration.Hours");
+                world.Entity<Durations.Days>("global::flecs.units.Duration.Days");
 
-                world.Entity<Times.CalenderDate>("::flecs::units::Time::Date");
+                world.Entity<Times.CalenderDate>("global::flecs.units.Time.Date");
 
-                world.Entity<Masses.Grams>("::flecs::units::Mass::Grams");
-                world.Entity<Masses.KiloGrams>("::flecs::units::Mass::KiloGrams");
+                world.Entity<Masses.Grams>("global::flecs.units.Mass.Grams");
+                world.Entity<Masses.KiloGrams>("global::flecs.units.Mass.KiloGrams");
 
-                world.Entity<ElectricCurrents.Ampere>("::flecs::units::ElectricCurrent::Ampere");
+                world.Entity<ElectricCurrents.Ampere>("global::flecs.units.ElectricCurrent.Ampere");
 
-                world.Entity<Amounts.Mole>("::flecs::units::Amount::Mole");
+                world.Entity<Amounts.Mole>("global::flecs.units.Amount.Mole");
 
-                world.Entity<LuminousIntensities.Candela>("::flecs::units::LuminousIntensity::Candela");
+                world.Entity<LuminousIntensities.Candela>("global::flecs.units.LuminousIntensity.Candela");
 
-                world.Entity<Forces.Newton>("::flecs::units::Force::Newton");
+                world.Entity<Forces.Newton>("global::flecs.units.Force.Newton");
 
-                world.Entity<Lengths.Meters>("::flecs::units::Length::Meters");
-                world.Entity<Lengths.PicoMeters>("::flecs::units::Length::PicoMeters");
-                world.Entity<Lengths.NanoMeters>("::flecs::units::Length::NanoMeters");
-                world.Entity<Lengths.MicroMeters>("::flecs::units::Length::MicroMeters");
-                world.Entity<Lengths.MilliMeters>("::flecs::units::Length::MilliMeters");
-                world.Entity<Lengths.CentiMeters>("::flecs::units::Length::CentiMeters");
-                world.Entity<Lengths.KiloMeters>("::flecs::units::Length::KiloMeters");
-                world.Entity<Lengths.Miles>("::flecs::units::Length::Miles");
-                world.Entity<Lengths.Pixels>("::flecs::units::Length::Pixels");
+                world.Entity<Lengths.Meters>("global::flecs.units.Length.Meters");
+                world.Entity<Lengths.PicoMeters>("global::flecs.units.Length.PicoMeters");
+                world.Entity<Lengths.NanoMeters>("global::flecs.units.Length.NanoMeters");
+                world.Entity<Lengths.MicroMeters>("global::flecs.units.Length.MicroMeters");
+                world.Entity<Lengths.MilliMeters>("global::flecs.units.Length.MilliMeters");
+                world.Entity<Lengths.CentiMeters>("global::flecs.units.Length.CentiMeters");
+                world.Entity<Lengths.KiloMeters>("global::flecs.units.Length.KiloMeters");
+                world.Entity<Lengths.Miles>("global::flecs.units.Length.Miles");
+                world.Entity<Lengths.Pixels>("global::flecs.units.Length.Pixels");
 
-                world.Entity<Pressures.Pascal>("::flecs::units::Pressure::Pascal");
-                world.Entity<Pressures.Bar>("::flecs::units::Pressure::Bar");
+                world.Entity<Pressures.Pascal>("global::flecs.units.Pressure.Pascal");
+                world.Entity<Pressures.Bar>("global::flecs.units.Pressure.Bar");
 
-                world.Entity<Speeds.MetersPerSecond>("::flecs::units::Speed::MetersPerSecond");
-                world.Entity<Speeds.KiloMetersPerSecond>("::flecs::units::Speed::KiloMetersPerSecond");
-                world.Entity<Speeds.KiloMetersPerHour>("::flecs::units::Speed::KiloMetersPerHour");
-                world.Entity<Speeds.MilesPerHour>("::flecs::units::Speed::MilesPerHour");
+                world.Entity<Speeds.MetersPerSecond>("global::flecs.units.Speed.MetersPerSecond");
+                world.Entity<Speeds.KiloMetersPerSecond>("global::flecs.units.Speed.KiloMetersPerSecond");
+                world.Entity<Speeds.KiloMetersPerHour>("global::flecs.units.Speed.KiloMetersPerHour");
+                world.Entity<Speeds.MilesPerHour>("global::flecs.units.Speed.MilesPerHour");
 
-                world.Entity<Temperatures.Kelvin>("::flecs::units::Temperature::Kelvin");
-                world.Entity<Temperatures.Celsius>("::flecs::units::Temperature::Celsius");
-                world.Entity<Temperatures.Fahrenheit>("::flecs::units::Temperature::Fahrenheit");
+                world.Entity<Temperatures.Kelvin>("global::flecs.units.Temperature.Kelvin");
+                world.Entity<Temperatures.Celsius>("global::flecs.units.Temperature.Celsius");
+                world.Entity<Temperatures.Fahrenheit>("global::flecs.units.Temperature.Fahrenheit");
 
-                world.Entity<Datas.Bits>("::flecs::units::Data::Bits");
-                world.Entity<Datas.KiloBits>("::flecs::units::Data::KiloBits");
-                world.Entity<Datas.MegaBits>("::flecs::units::Data::MegaBits");
-                world.Entity<Datas.GigaBits>("::flecs::units::Data::GigaBits");
-                world.Entity<Datas.Bytes>("::flecs::units::Data::Bytes");
-                world.Entity<Datas.KiloBytes>("::flecs::units::Data::KiloBytes");
-                world.Entity<Datas.MegaBytes>("::flecs::units::Data::MegaBytes");
-                world.Entity<Datas.GigaBytes>("::flecs::units::Data::GigaBytes");
-                world.Entity<Datas.KibiBytes>("::flecs::units::Data::KibiBytes");
-                world.Entity<Datas.MebiBytes>("::flecs::units::Data::MebiBytes");
-                world.Entity<Datas.GibiBytes>("::flecs::units::Data::GibiBytes");
+                world.Entity<Datas.Bits>("global::flecs.units.Data.Bits");
+                world.Entity<Datas.KiloBits>("global::flecs.units.Data.KiloBits");
+                world.Entity<Datas.MegaBits>("global::flecs.units.Data.MegaBits");
+                world.Entity<Datas.GigaBits>("global::flecs.units.Data.GigaBits");
+                world.Entity<Datas.Bytes>("global::flecs.units.Data.Bytes");
+                world.Entity<Datas.KiloBytes>("global::flecs.units.Data.KiloBytes");
+                world.Entity<Datas.MegaBytes>("global::flecs.units.Data.MegaBytes");
+                world.Entity<Datas.GigaBytes>("global::flecs.units.Data.GigaBytes");
+                world.Entity<Datas.KibiBytes>("global::flecs.units.Data.KibiBytes");
+                world.Entity<Datas.MebiBytes>("global::flecs.units.Data.MebiBytes");
+                world.Entity<Datas.GibiBytes>("global::flecs.units.Data.GibiBytes");
 
-                world.Entity<DataRates.BitsPerSecond>("::flecs::units::DataRate::BitsPerSecond");
-                world.Entity<DataRates.KiloBitsPerSecond>("::flecs::units::DataRate::KiloBitsPerSecond");
-                world.Entity<DataRates.MegaBitsPerSecond>("::flecs::units::DataRate::MegaBitsPerSecond");
-                world.Entity<DataRates.GigaBitsPerSecond>("::flecs::units::DataRate::GigaBitsPerSecond");
-                world.Entity<DataRates.BytesPerSecond>("::flecs::units::DataRate::BytesPerSecond");
-                world.Entity<DataRates.KiloBytesPerSecond>("::flecs::units::DataRate::KiloBytesPerSecond");
-                world.Entity<DataRates.MegaBytesPerSecond>("::flecs::units::DataRate::MegaBytesPerSecond");
-                world.Entity<DataRates.GigaBytesPerSecond>("::flecs::units::DataRate::GigaBytesPerSecond");
+                world.Entity<DataRates.BitsPerSecond>("global::flecs.units.DataRate.BitsPerSecond");
+                world.Entity<DataRates.KiloBitsPerSecond>("global::flecs.units.DataRate.KiloBitsPerSecond");
+                world.Entity<DataRates.MegaBitsPerSecond>("global::flecs.units.DataRate.MegaBitsPerSecond");
+                world.Entity<DataRates.GigaBitsPerSecond>("global::flecs.units.DataRate.GigaBitsPerSecond");
+                world.Entity<DataRates.BytesPerSecond>("global::flecs.units.DataRate.BytesPerSecond");
+                world.Entity<DataRates.KiloBytesPerSecond>("global::flecs.units.DataRate.KiloBytesPerSecond");
+                world.Entity<DataRates.MegaBytesPerSecond>("global::flecs.units.DataRate.MegaBytesPerSecond");
+                world.Entity<DataRates.GigaBytesPerSecond>("global::flecs.units.DataRate.GigaBytesPerSecond");
 
-                world.Entity<Frequencies.Hertz>("::flecs::units::Frequency::Hertz");
-                world.Entity<Frequencies.KiloHertz>("::flecs::units::Frequency::KiloHertz");
-                world.Entity<Frequencies.MegaHertz>("::flecs::units::Frequency::MegaHertz");
-                world.Entity<Frequencies.GigaHertz>("::flecs::units::Frequency::GigaHertz");
+                world.Entity<Frequencies.Hertz>("global::flecs.units.Frequency.Hertz");
+                world.Entity<Frequencies.KiloHertz>("global::flecs.units.Frequency.KiloHertz");
+                world.Entity<Frequencies.MegaHertz>("global::flecs.units.Frequency.MegaHertz");
+                world.Entity<Frequencies.GigaHertz>("global::flecs.units.Frequency.GigaHertz");
 
-                world.Entity<Uris.Hyperlink>("::flecs::units::Uri::Hyperlink");
-                world.Entity<Uris.Image>("::flecs::units::Uri::Image");
-                world.Entity<Uris.File>("::flecs::units::Uri::File");
+                world.Entity<Uris.Hyperlink>("global::flecs.units.Uri.Hyperlink");
+                world.Entity<Uris.Image>("global::flecs.units.Uri.Image");
+                world.Entity<Uris.File>("global::flecs.units.Uri.File");
 
-                world.Entity<Angles.Radians>("::flecs::units::Angle::Radians");
-                world.Entity<Angles.Degrees>("::flecs::units::Angle::Degrees");
+                world.Entity<Angles.Radians>("global::flecs.units.Angle.Radians");
+                world.Entity<Angles.Degrees>("global::flecs.units.Angle.Degrees");
 
-                world.Entity<Percentage>("::flecs::units::Percentage");
+                world.Entity<Percentage>("global::flecs.units.Percentage");
 
-                world.Entity<Bel>("::flecs::units::Bel");
-                world.Entity<DeciBel>("::flecs::units::DeciBel");
+                world.Entity<Bel>("global::flecs.units.Bel");
+                world.Entity<DeciBel>("global::flecs.units.DeciBel");
             }
 
             /// <summary>

--- a/src/Flecs.NET/Utilities/Managed.cs
+++ b/src/Flecs.NET/Utilities/Managed.cs
@@ -74,5 +74,15 @@ namespace Flecs.NET.Utilities
             StrongBox<T> obj = (StrongBox<T>)handle.Target!;
             return ref obj.Value;
         }
+
+        internal static ref T GetTypeRef<T>(IntPtr data, int index = 0)
+        {
+            if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                return ref ((T*)data)[index];
+
+            GCHandle handle = GCHandle.FromIntPtr(((IntPtr*)data)[index]);
+            StrongBox<T> obj = (StrongBox<T>)handle.Target!;
+            return ref obj.Value;
+        }
     }
 }

--- a/src/Flecs.NET/Utilities/NativeString.cs
+++ b/src/Flecs.NET/Utilities/NativeString.cs
@@ -71,7 +71,7 @@ namespace Flecs.NET.Utilities
             return (sbyte*)To(nativeString);
         }
 
-        public static explicit operator NativeString(string str)
+        public static explicit operator NativeString(string? str)
         {
             return FromString(str);
         }
@@ -96,7 +96,7 @@ namespace Flecs.NET.Utilities
             return (void*)nativeString.Data;
         }
 
-        public static NativeString FromString(string str)
+        public static NativeString FromString(string? str)
         {
             return new NativeString(Marshal.StringToHGlobalAnsi(str), false);
         }

--- a/src/Flecs.NET/Utilities/Utils.cs
+++ b/src/Flecs.NET/Utilities/Utils.cs
@@ -8,6 +8,21 @@ namespace Flecs.NET.Utilities
     public static unsafe class Utils
     {
         /// <summary>
+        ///     Checks if 2 native strings are equal.
+        /// </summary>
+        /// <param name="s1"></param>
+        /// <param name="s2"></param>
+        /// <returns></returns>
+        public static bool StringEqual(byte* s1, byte* s2)
+        {
+            while (*s1 == *s2++)
+                if (*s1++ == 0)
+                    return true;
+
+            return *s1 - *--s1 == 0;
+        }
+
+        /// <summary>
         ///     Gets the next power of 2 for the provided number.
         /// </summary>
         /// <param name="num"></param>


### PR DESCRIPTION
This PR ports the C++ ``ecs_cpp_component_register``, ``ecs_cpp_component_register_explicit``, and ``ecs_cpp_component_validate`` functions to make paths more closely resemble C#'s syntax by using dot separators. This introduces breaking changes to functions that take path arguments and existing code will need to be updated accordingly. A number of utility functions have been added to support type registration, and a bug involving incorrect type names in entity scopes was fixed.
```csharp
// Old
world.Lookup("::System::Span<System::Int32>");

// New
// Root separators are "::" and non-root separators are "."
world.Lookup("::System.Span<System.Int32>");
```