### PR TITLE
Add source generator for generic iter callbacks.

### DIFF
--- a/Flecs.NET.sln
+++ b/Flecs.NET.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flecs.NET.Native", "src\Fle
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flecs.NET.Benchmarks", "src\Flecs.NET.Benchmarks\Flecs.NET.Benchmarks.csproj", "{E92A406C-7470-44C7-9C1D-5613D9209A63}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Flecs.NET.Codegen", "src\Flecs.NET.Codegen\Flecs.NET.Codegen.csproj", "{A76AE670-D7DD-47DE-8F5C-DDF7B31C030A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,5 +50,9 @@ Global
 		{E92A406C-7470-44C7-9C1D-5613D9209A63}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E92A406C-7470-44C7-9C1D-5613D9209A63}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E92A406C-7470-44C7-9C1D-5613D9209A63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A76AE670-D7DD-47DE-8F5C-DDF7B31C030A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A76AE670-D7DD-47DE-8F5C-DDF7B31C030A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A76AE670-D7DD-47DE-8F5C-DDF7B31C030A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A76AE670-D7DD-47DE-8F5C-DDF7B31C030A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/Flecs.NET.Codegen/CodeFormatter.cs
+++ b/src/Flecs.NET.Codegen/CodeFormatter.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Flecs.NET.Codegen
+{
+    internal sealed class CodeFormatter : CSharpSyntaxRewriter
+    {
+        public static string Format(string source)
+        {
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+            SyntaxNode normalized = syntaxTree.GetRoot().NormalizeWhitespace();
+
+            normalized = new CodeFormatter().Visit(normalized);
+
+            return normalized.ToFullString();
+        }
+
+        private static T FormatMembers<T>(T node, IEnumerable<SyntaxNode> members) where T : SyntaxNode
+        {
+            SyntaxNode[] membersArray = members as SyntaxNode[] ?? members.ToArray();
+
+            int memberCount = membersArray.Length;
+            int current = 0;
+
+            return node.ReplaceNodes(membersArray, RewriteTrivia);
+
+            SyntaxNode RewriteTrivia<TNode>(TNode oldMember, TNode _) where TNode : SyntaxNode
+            {
+                string trailingTrivia = oldMember.GetTrailingTrivia().ToFullString().TrimEnd() + "\n\n";
+                return current++ != memberCount - 1
+                    ? oldMember.WithTrailingTrivia(SyntaxFactory.Whitespace(trailingTrivia))
+                    : oldMember;
+            }
+        }
+
+        public override SyntaxNode VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
+        {
+            return base.VisitNamespaceDeclaration(FormatMembers(node, node.Members));
+        }
+
+        public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            return base.VisitClassDeclaration(FormatMembers(node, node.Members));
+        }
+
+        public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
+        {
+            return base.VisitStructDeclaration(FormatMembers(node, node.Members));
+        }
+    }
+}

--- a/src/Flecs.NET.Codegen/Flecs.NET.Codegen.csproj
+++ b/src/Flecs.NET.Codegen/Flecs.NET.Codegen.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <AnalysisLevel>latest-all</AnalysisLevel>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+        <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/src/Flecs.NET.Codegen/Generator.cs
+++ b/src/Flecs.NET.Codegen/Generator.cs
@@ -1,0 +1,516 @@
+﻿using System;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Flecs.NET.Codegen
+{
+    [Generator]
+    public class Generator : IIncrementalGenerator
+    {
+        public const int GenericCount = 16;
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            context.RegisterPostInitializationOutput((IncrementalGeneratorPostInitializationContext postContext) =>
+            {
+                postContext.AddSource("Flecs.NET.g.cs", CodeFormatter.Format(Generate()));
+            });
+        }
+
+        public static string Generate()
+        {
+            return $@"
+                #nullable enable                
+
+                using System;
+                using System.Runtime.InteropServices;
+                using Flecs.NET.Utilities; 
+                using static Flecs.NET.Bindings.Native;
+
+                namespace Flecs.NET.Core 
+                {{
+                    {GenerateWorldExtensions()}
+                    {GenerateEcsExtensions()}
+                    {GenerateInvokerExtensions()}
+                    {GenerateBindingContextExtensions()}
+                    {GenerateFilterExtensions()}
+                    {GenerateQueryExtensions()}
+                    {GenerateRuleExtensions()}
+                }}
+            ";
+        }
+
+        public static string GenerateWorldExtensions()
+        {
+            return $@"
+                public unsafe partial struct World : IDisposable, IEquatable<World>
+                {{
+                    {GenerateFilterBuilderFactoryExtensions()}
+
+                    {GenerateRoutineFactoryExtensions("IterCallback", "RoutineIter")}
+                    {GenerateRoutineFactoryExtensions("EachCallback", "RoutineEach")}
+                    {GenerateRoutineFactoryExtensions("EachEntityCallback", "RoutineEachEntity")}
+                    {GenerateRoutineFactoryExtensions("EachIndexCallback", "RoutineEachIndex")}
+
+                    {GenerateObserverFactoryExtensions("IterCallback", "ObserverIter")}
+                    {GenerateObserverFactoryExtensions("EachCallback", "ObserverEach")}
+                    {GenerateObserverFactoryExtensions("EachEntityCallback", "ObserverEachEntity")}
+                    {GenerateObserverFactoryExtensions("EachIndexCallback", "ObserverEachIndex")}
+                }}
+            ";
+        }
+
+        public static string GenerateEcsExtensions()
+        {
+            return $@"
+                public static partial class Ecs 
+                {{
+                    {GenerateIterCallbacks()}
+                    {GenerateEachCallbacks()}
+                    {GenerateEachEntityCallbacks()}
+                    {GenerateEachIndexCallbacks()}
+                }}
+            ";
+        }
+
+        public static string GenerateInvokerExtensions()
+        {
+            return $@"
+                public static unsafe partial class Invoker 
+                {{
+                    {GenerateIterInvokers()}
+                    {GenerateEachInvokers()}
+                    {GenerateEachEntityInvokers()}
+                    {GenerateEachIndexInvokers()}
+                }}
+            ";
+        }
+
+        public static string GenerateFilterExtensions()
+        {
+            return $@"
+                public unsafe partial struct Filter : IDisposable
+                {{
+                    {GenerateCallbackFunctions("Iter", "IterCallback", "ecs_filter_iter", "ecs_filter_next")}
+                    {GenerateCallbackFunctions("Each", "EachCallback", "ecs_filter_iter", "ecs_filter_next_instanced")} 
+                    {GenerateCallbackFunctions("Each", "EachEntityCallback", "ecs_filter_iter", "ecs_filter_next_instanced")} 
+                    {GenerateCallbackFunctions("Each", "EachIndexCallback", "ecs_filter_iter", "ecs_filter_next_instanced")} 
+                }}
+            ";
+        }
+
+        public static string GenerateQueryExtensions()
+        {
+            return $@"
+                public unsafe partial struct Query : IDisposable
+                {{
+                    {GenerateCallbackFunctions("Iter", "IterCallback", "ecs_query_iter", "ecs_query_next")}
+                    {GenerateCallbackFunctions("Each", "EachCallback", "ecs_query_iter", "ecs_query_next_instanced")} 
+                    {GenerateCallbackFunctions("Each", "EachEntityCallback", "ecs_query_iter", "ecs_query_next_instanced")} 
+                    {GenerateCallbackFunctions("Each", "EachIndexCallback", "ecs_query_iter", "ecs_query_next_instanced")} 
+                }}
+            ";
+        }
+
+        public static string GenerateRuleExtensions()
+        {
+            return $@"
+                public unsafe partial struct Rule : IDisposable
+                {{
+                    {GenerateCallbackFunctions("Iter", "IterCallback", "ecs_rule_iter", "ecs_rule_next")}
+                    {GenerateCallbackFunctions("Each", "EachCallback", "ecs_rule_iter", "ecs_rule_next_instanced")} 
+                    {GenerateCallbackFunctions("Each", "EachEntityCallback", "ecs_rule_iter", "ecs_rule_next_instanced")} 
+                    {GenerateCallbackFunctions("Each", "EachIndexCallback", "ecs_rule_iter", "ecs_rule_next_instanced")} 
+                }}
+            ";
+        }
+
+        public static string GenerateBindingContextExtensions()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+
+                str.AppendLine($@"
+                    internal static unsafe partial class BindingContext<{typeParams}>
+                    {{
+                        #if NET5_0_OR_GREATER
+                        {GenerateBindingContextPointers(i, "RoutineIter")}
+                        {GenerateBindingContextPointers(i, "RoutineEach")}
+                        {GenerateBindingContextPointers(i, "RoutineEachEntity")}
+                        {GenerateBindingContextPointers(i, "RoutineEachIndex")}
+                        {GenerateBindingContextPointers(i, "ObserverIter")}
+                        {GenerateBindingContextPointers(i, "ObserverEach")}
+                        {GenerateBindingContextPointers(i, "ObserverEachEntity")}
+                        {GenerateBindingContextPointers(i, "ObserverEachIndex")}
+                        #else
+                        {GenerateBindingContextDelegates(i, "RoutineIter")}
+                        {GenerateBindingContextDelegates(i, "RoutineEach")}
+                        {GenerateBindingContextDelegates(i, "RoutineEachEntity")}
+                        {GenerateBindingContextDelegates(i, "RoutineEachIndex")}
+                        {GenerateBindingContextDelegates(i, "ObserverIter")}
+                        {GenerateBindingContextDelegates(i, "ObserverEach")}
+                        {GenerateBindingContextDelegates(i, "ObserverEachEntity")}
+                        {GenerateBindingContextDelegates(i, "ObserverEachIndex")}
+                        #endif
+                    }}
+                ");
+            }
+
+            return $@"
+                public static unsafe partial class BindingContext
+                {{
+                    {GenerateBindingContextCallbacks("Routine", "RoutineIter", "IterCallback", "Iter")}
+                    {GenerateBindingContextCallbacks("Routine", "RoutineEach", "EachCallback", "Each")}
+                    {GenerateBindingContextCallbacks("Routine", "RoutineEachEntity", "EachEntityCallback", "Each")}
+                    {GenerateBindingContextCallbacks("Routine", "RoutineEachIndex", "EachIndexCallback", "Each")}
+                    {GenerateBindingContextCallbacks("Observer", "ObserverIter", "IterCallback", "Iter")}
+                    {GenerateBindingContextCallbacks("Observer", "ObserverEach", "EachCallback", "Each")}
+                    {GenerateBindingContextCallbacks("Observer", "ObserverEachEntity", "EachEntityCallback", "Each")}
+                    {GenerateBindingContextCallbacks("Observer", "ObserverEachIndex", "EachIndexCallback", "Each")}
+                }}
+
+                {str}
+            ";
+        }
+
+        public static string GenerateFilterBuilderFactoryExtensions()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string termBuilders = ConcatString(i + 1, "\n", index => $".Term<T{index}>()");
+                str.AppendLine($@"
+                    public FilterBuilder FilterBuilder<{typeParams}>()
+                    {{
+                        return new FilterBuilder(Handle){termBuilders};
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateObserverFactoryExtensions(string delegateName, string callbackName)
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+
+                str.AppendLine($@"
+                    public Observer Observer<{typeParams}>(
+                        FilterBuilder filter = default,
+                        ObserverBuilder observer = default,
+                        Ecs.{delegateName}<{typeParams}>? callback = null,
+                        string name = """")
+                    {{
+                        return new Observer().InitObserver(
+                            false,
+                            BindingContext<{typeParams}>.{callbackName}Pointer,
+                            ref callback,
+                            ref Handle,
+                            ref filter,
+                            ref observer,
+                            ref name
+                        );
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateRoutineFactoryExtensions(string delegateName, string callbackName)
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+
+                str.AppendLine($@"
+                    public Routine Routine<{typeParams}>(
+                        FilterBuilder filter = default,
+                        QueryBuilder query = default,
+                        RoutineBuilder routine = default,
+                        Ecs.{delegateName}<{typeParams}>? callback = null,
+                        string name = """")
+                    {{
+                        return new Routine().InitRoutine(
+                            false,
+                            BindingContext<{typeParams}>.{callbackName}Pointer,
+                            ref callback,
+                            ref Handle,
+                            ref filter,
+                            ref query,
+                            ref routine,
+                            ref name
+                        );
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateIterCallbacks()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string funcParams = ConcatString(i + 1, ", ", index => $"Column<T{index}> comp{index}");
+                str.AppendLine($"public delegate void IterCallback<{typeParams}>(Iter it, {funcParams});");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateEachCallbacks()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string funcParams = ConcatString(i + 1, ", ", index => $"ref T{index} comp{index}");
+                str.AppendLine($"public delegate void EachCallback<{typeParams}>({funcParams});");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateEachEntityCallbacks()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string funcParams = ConcatString(i + 1, ", ", index => $"ref T{index} comp{index}");
+                str.AppendLine($"public delegate void EachEntityCallback<{typeParams}>(Entity entity, {funcParams});");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateEachIndexCallbacks()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string funcParams = ConcatString(i + 1, ", ", index => $"ref T{index} comp{index}");
+                str.AppendLine($"public delegate void EachIndexCallback<{typeParams}>(Iter it, int i, {funcParams});");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateIterInvokers()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string callbackArgs = ConcatString(i + 1, ", ", index => $"it.Field<{"T" + index}>({index + 1})");
+
+                str.AppendLine($@"
+                    public static void Iter<{typeParams}>(ecs_iter_t* iter, Ecs.IterCallback<{typeParams}> callback)
+                    {{
+                        Macros.TableLock(iter->world, iter->table);
+                        Iter it = new Iter(iter);
+                        callback(it, {callbackArgs});
+                        Macros.TableUnlock(iter->world, iter->table);
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateEachInvokers()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string typeAssertions = ConcatString(i + 1, "\n", index => $"Core.Iter.AssertFieldId<{"T" + index}>(iter, {index + 1});");
+                string callbackArgs = ConcatString(i + 1, ", ", index => $"ref Managed.GetTypeRef<{"T" + index}>(iter->ptrs[{index}], i)");
+
+                str.AppendLine($@"
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachCallback<{typeParams}> callback)
+                    {{
+                        Macros.TableLock(iter->world, iter->table);
+
+                        int count = iter->count == 0 ? 1 : iter->count;
+                        
+                        {typeAssertions}
+
+                        for (int i = 0; i < count; i++)
+                            callback({callbackArgs});
+
+                        Macros.TableUnlock(iter->world, iter->table);
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateEachEntityInvokers()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string typeAssertions = ConcatString(i + 1, "\n", index => $"Core.Iter.AssertFieldId<{"T" + index}>(iter, {index + 1});");
+                string callbackArgs = ConcatString(i + 1, ", ", index => $"ref Managed.GetTypeRef<{"T" + index}>(iter->ptrs[{index}], i)");
+
+                str.AppendLine($@"
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachEntityCallback<{typeParams}> callback)
+                    {{
+                        ecs_world_t* world = iter->world;
+                        int count = iter->count;
+
+                        Ecs.Assert(count > 0, ""No entities returned, use Each() without the entity argument instead."");
+                        {typeAssertions}
+
+                        Macros.TableLock(iter->world, iter->table);
+
+                        for (int i = 0; i < count; i++)
+                            callback(new Entity(world, iter->entities[i]), {callbackArgs});
+
+                        Macros.TableUnlock(iter->world, iter->table);
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateEachIndexInvokers()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+                string typeAssertions = ConcatString(i + 1, "\n", index => $"Core.Iter.AssertFieldId<{"T" + index}>(iter, {index + 1});");
+                string callbackArgs = ConcatString(i + 1, ", ", index => $"ref Managed.GetTypeRef<{"T" + index}>(iter->ptrs[{index}], i)");
+
+                str.AppendLine($@"
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachIndexCallback<{typeParams}> callback)
+                    {{
+                        int count = iter->count == 0 ? 1 : iter->count;
+
+                        Iter it = new Iter(iter);
+
+                        {typeAssertions}
+
+                        Macros.TableLock(iter->world, iter->table);
+
+                        for (int i = 0; i < count; i++)
+                            callback(it, i, {callbackArgs});
+
+                        Macros.TableUnlock(iter->world, iter->table);
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateBindingContextPointers(int index, string callbackName)
+        {
+            return $@"
+                internal static readonly IntPtr {callbackName}Pointer =
+                    (IntPtr)(delegate* <ecs_iter_t*, void>)&BindingContext.{callbackName}<{GenerateTypeParams(index + 1)}>;
+            ";
+        }
+
+        public static string GenerateBindingContextDelegates(int index, string functionName)
+        {
+            return $@"
+                internal static readonly IntPtr {functionName}Pointer =
+                    Marshal.GetFunctionPointerForDelegate({functionName}Reference = BindingContext.{functionName}<{GenerateTypeParams(index + 1)}>);
+                private static readonly Ecs.IterAction {functionName}Reference;
+            ";
+        }
+
+        public static string GenerateBindingContextCallbacks(string typeName, string callbackName, string delegateName, string invokerName)
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+
+                str.AppendLine($@"
+                    internal static void {callbackName}<{typeParams}>(ecs_iter_t* iter)
+                    {{
+                        {typeName}Context* context = ({typeName}Context*)iter->binding_ctx;
+                        Ecs.{delegateName}<{typeParams}> callback = (Ecs.{delegateName}<{typeParams}>)context->Iterator.GcHandle.Target!;
+                        Invoker.{invokerName}(iter, callback);
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateCallbackFunctions(string functionName, string delegateName, string iterName, string nextName)
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < GenericCount; i++)
+            {
+                string typeParams = GenerateTypeParams(i + 1);
+
+                str.AppendLine($@"
+                    public void {functionName}<{typeParams}>(Ecs.{delegateName}<{typeParams}> callback)
+                    {{
+                        ecs_iter_t iter = {iterName}(World, Handle);
+                        while ({nextName}(&iter) == 1)
+                            Invoker.{functionName}(&iter, callback);
+                    }}
+                ");
+            }
+
+            return str.ToString();
+        }
+
+        public static string ConcatString(int count, string separator, Func<int, string> callback)
+        {
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < count; i++)
+            {
+                str.Append(callback(i));
+                if (i < count - 1)
+                    str.Append(separator);
+            }
+
+            return str.ToString();
+        }
+
+        public static string GenerateTypeParams(int num)
+        {
+            return ConcatString(num, ", ", index => $"T{index}");
+        }
+    }
+}

--- a/src/Flecs.NET.Tests/Cpp/FilterBuilderTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/FilterBuilderTests.cs
@@ -1,10 +1,13 @@
+#region
+
 using Flecs.NET.Core;
 using Xunit;
-using static Flecs.NET.Bindings.Native;
+
+#endregion
 
 namespace Flecs.NET.Tests.Cpp
 {
-    public unsafe class FilterBuilderTests
+    public class FilterBuilderTests
     {
         public FilterBuilderTests()
         {
@@ -12,293 +15,14 @@ namespace Flecs.NET.Tests.Cpp
         }
 
         [Fact]
-        private void BuilderAssign()
+        public void BuilderAssignTypeArguments()
         {
-            using World world = World.Create();
+            World ecs = World.Create();
 
-            using Filter filter = world.Filter(
-                filter: world.FilterBuilder()
-                    .Term<Position>()
-                    .Term<Velocity>()
-            );
+            Filter q = ecs.Filter(ecs.FilterBuilder<Position, Velocity>());
 
-            Entity e1 = world.Entity().Add<Position>().Add<Velocity>();
-            Entity _ = world.Entity().Add<Position>();
-
-            int count = 0;
-
-            filter.Each(entity =>
-            {
-                count++;
-                Assert.True(entity == e1);
-            });
-
-            Assert.Equal(1, count);
-        }
-
-        [Fact]
-        private void BuilderFilterWrapper()
-        {
-            using World world = World.Create();
-
-            Entity e1 = world.Entity().Set(new Position { X = 10, Y = 20 });
-
-            Entity f = world.Entity().Set(new FilterWrapper
-            {
-                Filter = world.Filter(
-                    filter: world.FilterBuilder().Term<Position>()
-                )
-            });
-
-            int count = 0;
-
-            f.Get<FilterWrapper>().Filter.Each(entity =>
-            {
-                Assert.True(entity == e1);
-                count++;
-            });
-
-            Assert.Equal(1, count);
-            f.Get<FilterWrapper>().Filter.Dispose();
-        }
-
-        //
-        // [Fact]
-        // private void builder_build_n_statements() {
-        //     using World world = World.Create();
-        //
-        //     var qb = world.filter_builder<>();
-        //     qb.Term<Position>();
-        //     qb.Term<Velocity>();
-        //     var q = qb.build();
-        //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>();
-        //     world.Entity().Add<Position>();
-        //
-        //     int count = 0;
-        //     q.each([&](flecs::entity e) {
-        //         count ++;
-        //         Assert.True(e == e1);
-        //     });
-        //
-        //     Assert.Equal(1, count);
-        // }
-        //
-        // [Fact]
-        // private void 1_type() {
-        //     using World world = World.Create();
-        //
-        //     var q = world.filter_builder<Position>().build();
-        //
-        //     var e1 = world.Entity().Add<Position>();
-        //     world.Entity().Add<Velocity>();
-        //
-        //     int count = 0;
-        //     q.each([&](flecs::entity e, Position& p) {
-        //         count ++;
-        //         Assert.True(e == e1);
-        //     });
-        //
-        //     Assert.Equal(1, count);
-        // }
-        //
-        // [Fact]
-        // private void add_1_type() {
-        //     using World world = World.Create();
-        //
-        //     var q = world.filter_builder<>()
-        //         .Term<Position>()
-        //         .build();
-        //
-        //     var e1 = world.Entity().Add<Position>();
-        //     world.Entity().Add<Velocity>();
-        //
-        //     int count = 0;
-        //     q.each([&](flecs::entity e) {
-        //         count ++;
-        //         Assert.True(e == e1);
-        //     });
-        //
-        //     Assert.Equal(1, count);
-        // }
-        //
-        // [Fact]
-        // private void add_2_types() {
-        //     using World world = World.Create();
-        //
-        //     var q = world.filter_builder<>()
-        //         .Term<Position>()
-        //         .Term<Velocity>()
-        //         .build();
-        //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>();
-        //     world.Entity().Add<Velocity>();
-        //
-        //     int count = 0;
-        //     q.each([&](flecs::entity e) {
-        //         count ++;
-        //         Assert.True(e == e1);
-        //     });
-        //
-        //     Assert.Equal(1, count);
-        // }
-        //
-        // [Fact]
-        // private void add_1_type_w_1_type() {
-        //     using World world = World.Create();
-        //
-        //     var q = world.filter_builder<Position>()
-        //         .Term<Velocity>()
-        //         .build();
-        //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>();
-        //     world.Entity().Add<Velocity>();
-        //
-        //     int count = 0;
-        //     q.each([&](flecs::entity e, Position& p) {
-        //         count ++;
-        //         Assert.True(e == e1);
-        //     });
-        //
-        //     Assert.Equal(1, count);
-        // }
-        //
-        // [Fact]
-        // private void add_2_types_w_1_type() {
-        //     using World world = World.Create();
-        //
-        //     var q = world.filter_builder<Position>()
-        //         .Term<Velocity>()
-        //         .Term<Mass>()
-        //         .build();
-        //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>().Add<Mass>();
-        //     world.Entity().Add<Velocity>();
-        //
-        //     int count = 0;
-        //     q.each([&](flecs::entity e, Position& p) {
-        //         count ++;
-        //         Assert.True(e == e1);
-        //     });
-        //
-        //     Assert.Equal(1, count);
-        // }
-        //
-        [Fact]
-        private void AddPair()
-        {
-            using World world = World.Create();
-
-            Entity likes = world.Entity();
-            Entity bob = world.Entity();
-            Entity alice = world.Entity();
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder().Term(likes, bob)
-            );
-
-            Entity e1 = world.Entity().Add(likes, bob);
-            world.Entity().Add(likes, alice);
-
-            int count = 0;
-            q.Each(e =>
-            {
-                count++;
-                Assert.True(e == e1);
-            });
-
-            Assert.Equal(1, count);
-        }
-
-        [Fact]
-        private void AddNot()
-        {
-            using World world = World.Create();
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder()
-                    .Term<Position>()
-                    .Term<Velocity>().Oper(EcsNot)
-            );
-
-            Entity e1 = world.Entity().Add<Position>();
-            world.Entity().Add<Position>().Add<Velocity>();
-
-            int count = 0;
-            q.Each(e =>
-            {
-                count++;
-                Assert.True(e == e1);
-            });
-
-            Assert.Equal(1, count);
-        }
-
-        [Fact]
-        private void AddOr()
-        {
-            using World world = World.Create();
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder()
-                    .Term<Position>().Oper(EcsOr)
-                    .Term<Velocity>()
-            );
-
-            Entity e1 = world.Entity().Add<Position>();
-            Entity e2 = world.Entity().Add<Velocity>();
-            world.Entity().Add<Mass>();
-
-            int count = 0;
-            q.Each(e =>
-            {
-                count++;
-                Assert.True(e == e1 || e == e2);
-            });
-
-            Assert.Equal(2, count);
-        }
-
-        [Fact]
-        private void AddOptional()
-        {
-            using World world = World.Create();
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder()
-                    .Term<Position>()
-                    .Term<Velocity>().Oper(EcsOptional)
-            );
-
-            Entity e1 = world.Entity().Add<Position>();
-            Entity e2 = world.Entity().Add<Position>().Add<Velocity>();
-            world.Entity().Add<Velocity>().Add<Mass>();
-
-            int count = 0;
-            q.Each((Entity e) =>
-            {
-                count++;
-                Assert.True(e == e1 || e == e2);
-            });
-
-            Assert.Equal(2, count);
-        }
-
-
-        [Fact]
-        private void StringTerm()
-        {
-            using World world = World.Create();
-
-            world.Component<Position>();
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder()
-                    .Expr("Position")
-            );
-
-            Entity e1 = world.Entity().Add<Position>();
-            world.Entity().Add<Velocity>();
+            Entity e1 = ecs.Entity().Add<Position>().Add<Velocity>();
+            ecs.Entity().Add<Position>();
 
             int count = 0;
             q.Each((Entity e) =>
@@ -311,36 +35,221 @@ namespace Flecs.NET.Tests.Cpp
         }
 
         [Fact]
-        private void SingletonTerm()
+        public void BuilderAssignTerms()
         {
-            using World world = World.Create();
+            World ecs = World.Create();
 
-            world.Set(new Other { Value = 10 });
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder()
-                    .Term<Self>()
-                    .Term<Other>().Singleton()
+            Filter q = ecs.Filter(
+                ecs.FilterBuilder()
+                    .With<Position>()
+                    .With<Velocity>()
             );
 
-            Entity e = world.Entity();
+            Entity e1 = ecs.Entity().Add<Position>().Add<Velocity>();
+            ecs.Entity().Add<Position>();
+
+            int count = 0;
+            q.Each((Entity e) =>
+            {
+                count++;
+                Assert.True(e == e1);
+            });
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void AddPair()
+        {
+            World ecs = World.Create();
+
+            Entity likes = ecs.Entity();
+            Entity bob = ecs.Entity();
+            Entity alice = ecs.Entity();
+
+            Filter q = ecs.Filter(
+                ecs.FilterBuilder().With(likes, bob)
+            );
+
+            Entity e1 = ecs.Entity().Add(likes, bob);
+            ecs.Entity().Add(likes, alice);
+
+            int count = 0;
+            q.Each((Entity e) =>
+            {
+                count++;
+                Assert.True(e == e1);
+            });
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void AddNot()
+        {
+            World ecs = World.Create();
+
+            Filter q = ecs.Filter(
+                ecs.FilterBuilder<Position>()
+                    .With<Velocity>().Not()
+            );
+
+            Entity e1 = ecs.Entity().Add<Position>();
+            ecs.Entity().Add<Position>().Add<Velocity>();
+
+            int count = 0;
+            q.Each((Entity e) =>
+            {
+                count++;
+                Assert.True(e == e1);
+            });
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void AddOr()
+        {
+            World ecs = World.Create();
+
+            Filter q = ecs.Filter(
+                ecs.FilterBuilder()
+                    .With<Position>().Or()
+                    .With<Velocity>()
+            );
+
+            Entity e1 = ecs.Entity().Add<Position>();
+            Entity e2 = ecs.Entity().Add<Velocity>();
+            ecs.Entity().Add<Mass>();
+
+            int count = 0;
+            q.Each((Entity e) =>
+            {
+                count++;
+                Assert.True(e == e1 || e == e2);
+            });
+
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void AddOptional()
+        {
+            World ecs = World.Create();
+
+            Filter q = ecs.Filter(
+                ecs.FilterBuilder()
+                    .With<Position>()
+                    .With<Velocity>().Optional()
+            );
+
+            Entity e1 = ecs.Entity().Add<Position>();
+            Entity e2 = ecs.Entity().Add<Position>().Add<Velocity>();
+            ecs.Entity().Add<Velocity>().Add<Mass>();
+
+            int count = 0;
+            q.Each((Entity e) =>
+            {
+                count++;
+                Assert.True(e == e1 || e == e2);
+            });
+
+            Assert.Equal(2, count);
+        }
+
+        //
+        // [Fact]
+        // public void ptr_type()
+        // {
+        //     World ecs = World.Create();
+        //
+        //     var q = ecs.filter_builder<Position, Velocity*>().build();
+        //
+        //     var e1 = ecs.Entity().Add<Position>();
+        //     var e2 = ecs.Entity().Add<Position>().Add<Velocity>();
+        //     ecs.Entity().Add<Velocity>().Add<Mass>();
+        //
+        //     int count = 0;
+        //     q.Each((Entity e, ref Position p, Velocity* v) {
+        //         count ++;
+        //         Assert.True(e == e1 || e == e2);
+        //     });
+        //
+        //     Assert.Equal(2, count);
+        // }
+        //
+        // [Fact]
+        // public void const_type()
+        // {
+        //     World ecs = World.Create();
+        //
+        //     var q = ecs.filter_builder<const Position>().build();
+        //
+        //     var e1 = ecs.Entity().Add<Position>();
+        //     ecs.Entity().Add<Velocity>();
+        //
+        //     int count = 0;
+        //     q.Each((Entity e, const ref Position p) {
+        //         count ++;
+        //         Assert.True(e == e1);
+        //     });
+        //
+        //     Assert.Equal(1, count);
+        // }
+        //
+        [Fact]
+        public void StringTerm()
+        {
+            World ecs = World.Create();
+
+            ecs.Component<Position>();
+
+            Filter q = ecs.Filter(
+                ecs.FilterBuilder().Expr("Position")
+            );
+
+            Entity e1 = ecs.Entity().Add<Position>();
+            ecs.Entity().Add<Velocity>();
+
+            int count = 0;
+            q.Each((Entity e) =>
+            {
+                count++;
+                Assert.True(e == e1);
+            });
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void singleton_term()
+        {
+            World ecs = World.Create();
+
+            ecs.Set(new Other { Value = 10 });
+
+            Filter q = ecs.Filter(
+                ecs.FilterBuilder<Self>()
+                    .With<Other>().Singleton()
+            );
+
+            Entity
+                e = ecs.Entity();
             e.Set(new Self { Value = e });
-            e = world.Entity();
+            e = ecs.Entity();
             e.Set(new Self { Value = e });
-            e = world.Entity();
+            e = ecs.Entity();
             e.Set(new Self { Value = e });
 
             int count = 0;
 
-            q.Iter(it =>
+            q.Iter((Iter it, Column<Self> s) =>
             {
-                Column<Self> s = it.Field<Self>(1);
                 Column<Other> o = it.Field<Other>(2);
-
                 Assert.True(!it.IsSelf(2));
                 Assert.Equal(10, o[0].Value);
 
-                ref readonly Other oRef = ref o[0];
+                ref Other oRef = ref o[0];
                 Assert.Equal(10, oRef.Value);
 
                 foreach (int i in it)
@@ -352,118 +261,27 @@ namespace Flecs.NET.Tests.Cpp
 
             Assert.Equal(3, count);
         }
-
-        [Fact]
-        private void IsASupersetTerm()
-        {
-            using World world = World.Create();
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder()
-                    .Term<Self>()
-                    .Term<Other>().Src().Up()
-            );
-
-            Entity @base = world.Entity().Set(new Other { Value = 10 });
-
-            Entity e = world.Entity().Add(EcsIsA, @base);
-            e.Set(new Self { Value = e });
-            e = world.Entity().Add(EcsIsA, @base);
-            e.Set(new Self { Value = e });
-            e = world.Entity().Add(EcsIsA, @base);
-            e.Set(new Self { Value = e });
-
-            int count = 0;
-
-            q.Iter(it =>
-            {
-                Column<Self> s = it.Field<Self>(1);
-                Column<Other> o = it.Field<Other>(2);
-
-                Assert.True(!it.IsSelf(2));
-                Assert.Equal(10, o[0].Value);
-
-                foreach (int i in it)
-                {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
-                }
-            });
-
-            Assert.Equal(3, count);
-        }
-
-        [Fact]
-        private void IsASelfSupersetTerm()
-        {
-            using World world = World.Create();
-
-            using Filter q = world.Filter(
-                filter: world.FilterBuilder()
-                    .Term<Self>()
-                    .Term<Other>().Src().Self().Up()
-            );
-
-            Entity @base = world.Entity().Set(new Other { Value = 10 });
-
-            Entity e = world.Entity().Add(EcsIsA, @base);
-            e.Set(new Self { Value = e });
-            e = world.Entity().Add(EcsIsA, @base);
-            e.Set(new Self { Value = e });
-            e = world.Entity().Add(EcsIsA, @base);
-            e.Set(new Self { Value = e });
-            e = world.Entity().Set(new Other { Value = 20 });
-            e.Set(new Self { Value = e });
-            e = world.Entity().Set(new Other { Value = 20 });
-            e.Set(new Self { Value = e });
-
-            int count = 0;
-            int ownedCount = 0;
-
-            q.Iter(it =>
-            {
-                Column<Self> s = it.Field<Self>(1);
-                Column<Other> o = it.Field<Other>(2);
-
-                if (!it.IsSelf(2))
-                    Assert.Equal(10, o[0].Value);
-                else
-                    foreach (int i in it)
-                    {
-                        Assert.Equal(20, o[i].Value);
-                        ownedCount++;
-                    }
-
-                foreach (int i in it)
-                {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
-                }
-            });
-
-            Assert.Equal(5, count);
-            Assert.Equal(2, ownedCount);
-        }
         //
         // [Fact]
-        // private void childof_superset_term() {
-        //     using World world = World.Create();
+        // public void isa_superSet_term()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self>()
-        //         .Term<Other>().src().up(flecs::ChildOf)
+        //     var q = ecs.filter_builder<Self>()
+        //         .With<Other>().src().up()
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.iter([&](flecs::iter& it, Self *s) {
-        //         var o = it.field<const Other>(2);
+        //     q.Iter((Iter it, Column<Self> s) => {
+        //         var o = it.Field<const Other>(2);
         //         Assert.True(!it.IsSelf(2));
         //         Assert.Equal(o->value, 10);
         //
@@ -473,31 +291,32 @@ namespace Flecs.NET.Tests.Cpp
         //         }
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void childof_self_superset_term() {
-        //     using World world = World.Create();
+        // public void isa_self_superSet_term()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self>()
-        //         .Term<Other>().src().self().up(flecs::ChildOf)
+        //     var q = ecs.filter_builder<Self>()
+        //         .With<Other>().src().self().up()
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 20 }); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 20 }); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 20}); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 20}); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //     int owned_count = 0;
         //
-        //     q.iter([&](flecs::iter& it, Self *s) {
-        //         var o = it.field<const Other>(2);
+        //     q.Iter((Iter it, Column<Self> s) => {
+        //         var o = it.Field<const Other>(2);
         //
         //         if (!it.IsSelf(2)) {
         //             Assert.Equal(o->value, 10);
@@ -519,51 +338,128 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void isa_superset_term_w_each() {
-        //     using World world = World.Create();
+        // public void childof_superSet_term()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
+        //     var q = ecs.filter_builder<Self>()
+        //         .With<Other>().src().up(flecs::ChildOf)
+        //         .build();
+        //
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
+        //
+        //     var
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //
+        //     int count = 0;
+        //
+        //     q.Iter((Iter it, Column<Self> s) => {
+        //         var o = it.Field<const Other>(2);
+        //         Assert.True(!it.IsSelf(2));
+        //         Assert.Equal(o->value, 10);
+        //
+        //         foreach (int i in it) {
+        //             Assert.True(it.Entity(i) == s[i].Value);
+        //             count ++;
+        //         }
+        //     });
+        //
+        //     Assert.Equal(count, 3);
+        // }
+        //
+        // [Fact]
+        // public void childof_self_superSet_term()
+        // {
+        //     World ecs = World.Create();
+        //
+        //     var q = ecs.filter_builder<Self>()
+        //         .With<Other>().src().self().up(flecs::ChildOf)
+        //         .build();
+        //
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
+        //
+        //     var
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 20}); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 20}); e.Set(new Self { Value = e});
+        //
+        //     int count = 0;
+        //     int owned_count = 0;
+        //
+        //     q.Iter((Iter it, Column<Self> s) => {
+        //         var o = it.Field<const Other>(2);
+        //
+        //         if (!it.IsSelf(2)) {
+        //             Assert.Equal(o->value, 10);
+        //         } else {
+        //             foreach (int i in it) {
+        //                 Assert.Equal(o[i].Value, 20);
+        //                 owned_count ++;
+        //             }
+        //         }
+        //
+        //         foreach (int i in it) {
+        //             Assert.True(it.Entity(i) == s[i].Value);
+        //             count ++;
+        //         }
+        //     });
+        //
+        //     Assert.Equal(count, 5);
+        //     Assert.Equal(owned_count, 2);
+        // }
+        //
+        // [Fact]
+        // public void isa_superSet_term_w_each()
+        // {
+        //     World ecs = World.Create();
+        //
+        //     var q = ecs.filter_builder<Self, Other>()
         //         .arg(2).src().up()
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().Add(EcsIsA, @base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(EcsIsA, @base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(EcsIsA, @base); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void isa_self_superset_term_w_each() {
-        //     using World world = World.Create();
+        // public void isa_self_superSet_term_w_each()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
+        //     var q = ecs.filter_builder<Self, Other>()
         //         .arg(2).src().self().up()
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().Add(EcsIsA, @base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(EcsIsA, @base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(EcsIsA, @base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(flecs::IsA, base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
@@ -573,51 +469,53 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void childof_superset_term_w_each() {
-        //     using World world = World.Create();
+        // public void childof_superSet_term_w_each()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
+        //     var q = ecs.filter_builder<Self, Other>()
         //         .arg(2).src().up(flecs::ChildOf)
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void childof_self_superset_term_w_each() {
-        //     using World world = World.Create();
+        // public void childof_self_superSet_term_w_each()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
+        //     var q = ecs.filter_builder<Self, Other>()
         //         .arg(2).src().self().up(flecs::ChildOf)
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
@@ -627,51 +525,53 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void isa_superset_shortcut() {
-        //     using World world = World.Create();
+        // public void isa_superSet_shortcut()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
+        //     var q = ecs.filter_builder<Self, Other>()
         //         .arg(2).up()
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().is_a(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().is_a(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().is_a(@base); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().is_a(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().is_a(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().is_a(base); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void isa_superset_shortcut_w_self() {
-        //     using World world = World.Create();
+        // public void isa_superSet_shortcut_w_self()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
-        //         .arg(2).self().up(EcsIsA)
+        //     var q = ecs.filter_builder<Self, Other>()
+        //         .arg(2).self().up(flecs::IsA)
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().is_a(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().is_a(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().is_a(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().is_a(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().is_a(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().is_a(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
@@ -681,51 +581,53 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void childof_superset_shortcut() {
-        //     using World world = World.Create();
+        // public void childof_superSet_shortcut()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
+        //     var q = ecs.filter_builder<Self, Other>()
         //         .arg(2).up(flecs::ChildOf)
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void childof_superset_shortcut_w_self() {
-        //     using World world = World.Create();
+        // public void childof_superSet_shortcut_w_self()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Self, Other>()
+        //     var q = ecs.filter_builder<Self, Other>()
         //         .arg(2).self().up(flecs::ChildOf)
         //         .build();
         //
-        //     var @base = world.Entity().Set(new Other { Value = 10 });
+        //     var base = ecs.Entity().Set(new Other { Value = 10});
         //
         //     var
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().child_of(@base); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
-        //     e = world.Entity().Set(new Other { Value = 10 }); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().child_of(base); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Set(new Other { Value = 10}); e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s, Other& o) {
+        //     q.Each((Entity e, Self& s, Other& o) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(o.Value, 10);
         //         count ++;
@@ -735,27 +637,28 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void relation() {
-        //     using World world = World.Create();
+        // public void relation()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Likes = world.Entity();
-        //     var Bob = world.Entity();
-        //     var Alice = world.Entity();
+        //     var Likes = ecs.Entity();
+        //     var Bob = ecs.Entity();
+        //     var Alice = ecs.Entity();
         //
-        //     var q = world.filter_builder<Self>()
+        //     var q = ecs.filter_builder<Self>()
         //         .term(Likes, Bob)
         //         .build();
         //
         //     var
-        //     e = world.Entity().Add(Likes, Bob); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(Likes, Bob); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(Likes, Bob); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(Likes, Bob); e.Set(new Self { Value = e});
         //
-        //     e = world.Entity().Add(Likes, Alice); e.set<Self>({0});
-        //     e = world.Entity().Add(Likes, Alice); e.set<Self>({0});
+        //     e = ecs.Entity().Add(Likes, Alice); e.Set(new Self { Value = 0});
+        //     e = ecs.Entity().Add(Likes, Alice); e.Set(new Self { Value = 0});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s) {
+        //     q.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
@@ -764,30 +667,31 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void relation_w_object_wildcard() {
-        //     using World world = World.Create();
+        // public void relation_w_object_wildcard()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Likes = world.Entity();
-        //     var Bob = world.Entity();
-        //     var Alice = world.Entity();
+        //     var Likes = ecs.Entity();
+        //     var Bob = ecs.Entity();
+        //     var Alice = ecs.Entity();
         //
-        //     var q = world.filter_builder<Self>()
+        //     var q = ecs.filter_builder<Self>()
         //         .term(Likes, flecs::Wildcard)
         //         .build();
         //
         //     var
-        //     e = world.Entity().Add(Likes, Bob); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(Likes, Bob); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(Likes, Bob); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(Likes, Bob); e.Set(new Self { Value = e});
         //
-        //     e = world.Entity().Add(Likes, Alice); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(Likes, Alice); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(Likes, Alice); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(Likes, Alice); e.Set(new Self { Value = e});
         //
-        //     e = world.Entity(); e.set<Self>({0});
-        //     e = world.Entity(); e.set<Self>({0});
+        //     e = ecs.Entity(); e.Set(new Self { Value = 0});
+        //     e = ecs.Entity(); e.Set(new Self { Value = 0});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s) {
+        //     q.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
@@ -796,28 +700,29 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void relation_w_predicate_wildcard() {
-        //     using World world = World.Create();
+        // public void relation_w_predicate_wildcard()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Likes = world.Entity();
-        //     var Dislikes = world.Entity();
-        //     var Bob = world.Entity();
-        //     var Alice = world.Entity();
+        //     var Likes = ecs.Entity();
+        //     var Dislikes = ecs.Entity();
+        //     var Bob = ecs.Entity();
+        //     var Alice = ecs.Entity();
         //
-        //     var q = world.filter_builder<Self>()
+        //     var q = ecs.filter_builder<Self>()
         //         .term(flecs::Wildcard, Alice)
         //         .build();
         //
         //     var
-        //     e = world.Entity().Add(Likes, Alice); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(Dislikes, Alice); e.Set(new Self { Value = e });
+        //     e = ecs.Entity().Add(Likes, Alice); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(Dislikes, Alice); e.Set(new Self { Value = e});
         //
-        //     e = world.Entity().Add(Likes, Bob); e.set<Self>({0});
-        //     e = world.Entity().Add(Dislikes, Bob); e.set<Self>({0});
+        //     e = ecs.Entity().Add(Likes, Bob); e.Set(new Self { Value = 0});
+        //     e = ecs.Entity().Add(Dislikes, Bob); e.Set(new Self { Value = 0});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s) {
+        //     q.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
@@ -826,29 +731,30 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void add_pair_w_rel_type() {
-        //     using World world = World.Create();
+        // public void add_pair_w_rel_type()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
         //
-        //     var Dislikes = world.Entity();
-        //     var Bob = world.Entity();
-        //     var Alice = world.Entity();
+        //     var Dislikes = ecs.Entity();
+        //     var Bob = ecs.Entity();
+        //     var Alice = ecs.Entity();
         //
-        //     var q = world.filter_builder<Self>()
-        //         .Term<Likes>(flecs::Wildcard)
+        //     var q = ecs.filter_builder<Self>()
+        //         .With<Likes>(flecs::Wildcard)
         //         .build();
         //
         //     var
-        //     e = world.Entity().Add<Likes>(Alice); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(Dislikes, Alice); e.set<Self>({0});
+        //     e = ecs.Entity().Add<Likes>(Alice); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(Dislikes, Alice); e.Set(new Self { Value = 0});
         //
-        //     e = world.Entity().Add<Likes>(Bob); e.Set(new Self { Value = e });
-        //     e = world.Entity().Add(Dislikes, Bob); e.set<Self>({0});
+        //     e = ecs.Entity().Add<Likes>(Bob); e.Set(new Self { Value = e});
+        //     e = ecs.Entity().Add(Dislikes, Bob); e.Set(new Self { Value = 0});
         //
         //     int count = 0;
         //
-        //     q.each([&](flecs::entity e, Self& s) {
+        //     q.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
@@ -857,18 +763,19 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void template_term() {
-        //     using World world = World.Create();
+        // public void template_term()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Position>()
-        //         .Term<Template<int>>()
+        //     var q = ecs.filter_builder<Position>()
+        //         .With<Template<int>>()
         //         .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Template<int>>();
-        //     world.Entity().Add<Position>();
+        //     var e1 = ecs.Entity().Add<Position>().Add<Template<int>>();
+        //     ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e, Position& p) {
+        //     q.Each((Entity e, ref Position p) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -877,18 +784,19 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_subject_w_id() {
-        //     using World world = World.Create();
+        // public void explicit_subject_w_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<Position>()
-        //         .Term<Position>().id(flecs::This)
+        //     var q = ecs.filter_builder<Position>()
+        //         .With<Position>().id(flecs::This)
         //         .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>();
-        //     world.Entity().Add<Velocity>();
+        //     var e1 = ecs.Entity().Add<Position>().Add<Velocity>();
+        //     ecs.Entity().Add<Velocity>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e, Position& p) {
+        //     q.Each((Entity e, ref Position p) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -897,43 +805,45 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_subject_w_type() {
-        //     using World world = World.Create();
+        // public void explicit_subject_w_type()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Set(new Position { X = 10, Y = 20 });
+        //     ecs.Set<Position>({10, 20});
         //
-        //     var q = world.filter_builder<Position>()
-        //         .Term<Position>().src<Position>()
+        //     var q = ecs.filter_builder<Position>()
+        //         .With<Position>().src<Position>()
         //         .build();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e, Position& p) {
+        //     q.Each((Entity e, ref Position p) => {
         //         Assert.Equal(p.x, 10);
         //         Assert.Equal(p.y, 20);
         //         count ++;
-        //         Assert.True(e == world.singleton<Position>());
+        //         Assert.True(e == ecs.singleton<Position>());
         //     });
         //
         //     Assert.Equal(1, count);
         // }
         //
         // [Fact]
-        // private void explicit_object_w_id() {
-        //     using World world = World.Create();
+        // public void explicit_object_w_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Likes = world.Entity("Likes");
-        //     var Alice = world.Entity("Alice");
-        //     var Bob = world.Entity("Bob");
+        //     var Likes = ecs.Entity("Likes");
+        //     var Alice = ecs.Entity("Alice");
+        //     var Bob = ecs.Entity("Bob");
         //
-        //     var q = world.filter_builder<>()
+        //     var q = ecs.filter_builder<>()
         //         .term(Likes).second(Alice)
         //         .build();
         //
-        //     var e1 = world.Entity().Add(Likes, Alice);
-        //     world.Entity().Add(Likes, Bob);
+        //     var e1 = ecs.Entity().Add(Likes, Alice);
+        //     ecs.Entity().Add(Likes, Bob);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -942,22 +852,23 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_object_w_type() {
-        //     using World world = World.Create();
+        // public void explicit_object_w_type()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Likes = world.Entity();
+        //     var Likes = ecs.Entity();
         //     struct Alice { };
-        //     var Bob = world.Entity();
+        //     var Bob = ecs.Entity();
         //
-        //     var q = world.filter_builder<>()
+        //     var q = ecs.filter_builder<>()
         //         .term(Likes).second<Alice>()
         //         .build();
         //
-        //     var e1 = world.Entity().Add(Likes, world.id<Alice>());
-        //     world.Entity().Add(Likes, Bob);
+        //     var e1 = ecs.Entity().Add(Likes, ecs.id<Alice>());
+        //     ecs.Entity().Add(Likes, Bob);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -966,18 +877,19 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_term() {
-        //     using World world = World.Create();
+        // public void explicit_term()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<>()
-        //         .term(world.Term<Position>())
+        //     var q = ecs.filter_builder<>()
+        //         .term(ecs.With<Position>())
         //         .build();
         //
-        //     var e1 = world.Entity().Add<Position>();
-        //     world.Entity().Add<Velocity>();
+        //     var e1 = ecs.Entity().Add<Position>();
+        //     ecs.Entity().Add<Velocity>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -986,18 +898,19 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_term_w_type() {
-        //     using World world = World.Create();
+        // public void explicit_term_w_type()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder<>()
-        //         .term(world.Term<Position>())
+        //     var q = ecs.filter_builder<>()
+        //         .term(ecs.With<Position>())
         //         .build();
         //
-        //     var e1 = world.Entity().Add<Position>();
-        //     world.Entity().Add<Velocity>();
+        //     var e1 = ecs.Entity().Add<Position>();
+        //     ecs.Entity().Add<Velocity>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1006,22 +919,23 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_term_w_pair_type() {
-        //     using World world = World.Create();
+        // public void explicit_term_w_pair_type()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
         //     struct Alice { };
         //     struct Bob { };
         //
-        //     var q = world.filter_builder<>()
-        //         .term(world.Term<Likes, Alice>())
+        //     var q = ecs.filter_builder<>()
+        //         .term(ecs.With<Likes, Alice>())
         //         .build();
         //
-        //     var e1 = world.Entity().Add<Likes, Alice>();
-        //     world.Entity().Add<Likes, Bob>();
+        //     var e1 = ecs.Entity().Add<Likes, Alice>();
+        //     ecs.Entity().Add<Likes, Bob>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1030,21 +944,22 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_term_w_id() {
-        //     using World world = World.Create();
+        // public void explicit_term_w_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Apples = world.Entity();
-        //     var Pears = world.Entity();
+        //     var Apples = ecs.Entity();
+        //     var Pears = ecs.Entity();
         //
-        //     var q = world.filter_builder<>()
-        //         .term(world.term(Apples))
+        //     var q = ecs.filter_builder<>()
+        //         .term(ecs.term(Apples))
         //         .build();
         //
-        //     var e1 = world.Entity().Add(Apples);
-        //     world.Entity().Add(Pears);
+        //     var e1 = ecs.Entity().Add(Apples);
+        //     ecs.Entity().Add(Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1053,22 +968,23 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void explicit_term_w_pair_id() {
-        //     using World world = World.Create();
+        // public void explicit_term_w_pair_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Likes = world.Entity();
-        //     var Apples = world.Entity();
-        //     var Pears = world.Entity();
+        //     var Likes = ecs.Entity();
+        //     var Apples = ecs.Entity();
+        //     var Pears = ecs.Entity();
         //
-        //     var q = world.filter_builder<>()
-        //         .term(world.term(Likes, Apples))
+        //     var q = ecs.filter_builder<>()
+        //         .term(ecs.term(Likes, Apples))
         //         .build();
         //
-        //     var e1 = world.Entity().Add(Likes, Apples);
-        //     world.Entity().Add(Likes, Pears);
+        //     var e1 = ecs.Entity().Add(Likes, Apples);
+        //     ecs.Entity().Add(Likes, Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1077,41 +993,43 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void 1_term_to_empty() {
-        //     using World world = World.Create();
+        // public void 1_term_to_empty()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var Likes = world.Entity();
-        //     var Apples = world.Entity();
+        //     var Likes = ecs.Entity();
+        //     var Apples = ecs.Entity();
         //
-        //     var qb = world.filter_builder<>()
-        //         .Term<Position>();
+        //     var qb = ecs.filter_builder<>()
+        //         .With<Position>();
         //
         //     qb.term(Likes, Apples);
         //
         //     var q = qb.build();
         //
         //     Assert.Equal(q.field_count(), 2);
-        //     Assert.Equal(q.term(0).id(), world.id<Position>());
-        //     Assert.Equal(q.term(1).id(), world.pair(Likes, Apples));
+        //     Assert.Equal(q.term(0).id(), ecs.id<Position>());
+        //     Assert.Equal(q.term(1).id(), ecs.pair(Likes, Apples));
         // }
         //
         // [Fact]
-        // private void 2_subsequent_args() {
-        //     using World world = World.Create();
+        // public void 2_subsequent_args()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Rel { int foo; };
         //
         //     int count = 0;
         //
-        //     var s = world.system<Rel, const Velocity>()
+        //     var s = ecs.system<Rel, const Velocity>()
         //         .arg(1).second(flecs::Wildcard)
-        //         .arg(2).singleton()
+        //         .arg(2).Singleton()
         //         .iter([&](flecs::iter it){
         //             count += it.count();
         //         });
         //
-        //     world.Entity().Add<Rel, Tag>();
-        //     world.set<Velocity>({});
+        //     ecs.Entity().Add<Rel, Tag>();
+        //     ecs.Set<Velocity>({});
         //
         //     s.run();
         //
@@ -1122,7 +1040,7 @@ namespace Flecs.NET.Tests.Cpp
         // int filter_arg(flecs::filter<Self> f) {
         //     int count = 0;
         //
-        //     f.each([&](flecs::entity e, Self& s) {
+        //     f.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
@@ -1131,19 +1049,20 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void filter_as_arg() {
-        //     using World world = World.Create();
+        // public void filter_as_arg()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var f = world.filter<Self>();
+        //     var f = ecs.filter<Self>();
         //
-        //     var e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     var e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
         //     Assert.Equal(filter_arg(f), 3);
         // }
@@ -1152,7 +1071,7 @@ namespace Flecs.NET.Tests.Cpp
         // int filter_move_arg(flecs::filter<Self>&& f) {
         //     int count = 0;
         //
-        //     f.each([&](flecs::entity e, Self& s) {
+        //     f.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
@@ -1161,181 +1080,188 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void filter_as_move_arg() {
-        //     using World world = World.Create();
+        // public void filter_as_move_arg()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var f = world.filter<Self>();
+        //     var f = ecs.filter<Self>();
         //
-        //     var e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     var e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     Assert.Equal(filter_move_arg(world.filter<Self>()), 3);
+        //     Assert.Equal(filter_move_arg(ecs.filter<Self>()), 3);
         // }
         //
         // static
         // flecs::filter<Self> filter_return(flecs::world& ecs) {
-        //     return world.filter<Self>();
+        //     return ecs.filter<Self>();
         // }
         //
         // [Fact]
-        // private void filter_as_return() {
-        //     using World world = World.Create();
+        // public void filter_as_return()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     var e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
         //     var f = filter_return(ecs);
         //
         //     int count = 0;
         //
-        //     f.each([&](flecs::entity e, Self& s) {
+        //     f.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void filter_copy() {
-        //     using World world = World.Create();
+        // public void filter_copy()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     var e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     var f = world.filter<Self>();
+        //     var f = ecs.filter<Self>();
         //
         //     var f_2 = f;
         //
         //     int count = 0;
         //
-        //     f_2.each([&](flecs::entity e, Self& s) {
+        //     f_2.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void world_each_filter_1_component() {
-        //     using World world = World.Create();
+        // public void world_each_filter_1_component()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     var e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e});
         //
         //     int count = 0;
         //
-        //     world.each([&](flecs::entity e, Self& s) {
+        //     ecs.Each((Entity e, Self& s) {
         //         Assert.True(e == s.Value);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void world_each_filter_2_components() {
-        //     using World world = World.Create();
+        // public void world_each_filter_2_components()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var e = world.Entity();
-        //     e.Set(new Self { Value = e })
-        //      .Set(new Position { X = 10, Y = 20 });
+        //     var e = ecs.Entity();
+        //     e.Set(new Self { Value = e})
+        //      .Set<Position>({10, 20});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e })
-        //         .Set(new Position { X = 10, Y = 20 });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e})
+        //         .Set<Position>({10, 20});
         //
-        //     e = world.Entity();
-        //     e.Set(new Self { Value = e })
-        //      .Set(new Position { X = 10, Y = 20 });
+        //     e = ecs.Entity();
+        //     e.Set(new Self { Value = e})
+        //      .Set<Position>({10, 20});
         //
         //     int count = 0;
         //
-        //     world.each([&](flecs::entity e, Self& s, Position& p) {
+        //     ecs.Each((Entity e, Self& s, ref Position p) {
         //         Assert.True(e == s.Value);
         //         Assert.Equal(p.x, 10);
         //         Assert.Equal(p.y, 20);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void world_each_filter_1_component_no_entity() {
-        //     using World world = World.Create();
+        // public void world_each_filter_1_component_no_entity()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Entity()
-        //         .Set(new Position { X = 10, Y = 20 });
+        //     ecs.Entity()
+        //         .Set<Position>({10, 20});
         //
-        //     world.Entity()
-        //         .Set(new Position { X = 10, Y = 20 });
+        //     ecs.Entity()
+        //         .Set<Position>({10, 20});
         //
-        //     world.Entity()
-        //         .Set(new Position { X = 10, Y = 20 })
-        //         .set<Velocity>({1, 2});
+        //     ecs.Entity()
+        //         .Set<Position>({10, 20})
+        //         .Set<Velocity>({1, 2});
         //
         //     int count = 0;
         //
-        //     world.each([&](Position& p) {
+        //     ecs.each([&](ref Position p) {
         //         Assert.Equal(p.x, 10);
         //         Assert.Equal(p.y, 20);
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void world_each_filter_2_components_no_entity() {
-        //     using World world = World.Create();
+        // public void world_each_filter_2_components_no_entity()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Entity()
-        //         .Set(new Position { X = 10, Y = 20 })
-        //         .set<Velocity>({1, 2});
+        //     ecs.Entity()
+        //         .Set<Position>({10, 20})
+        //         .Set<Velocity>({1, 2});
         //
-        //     world.Entity()
-        //         .Set(new Position { X = 10, Y = 20 })
-        //         .set<Velocity>({1, 2});
+        //     ecs.Entity()
+        //         .Set<Position>({10, 20})
+        //         .Set<Velocity>({1, 2});
         //
-        //     world.Entity()
-        //         .Set(new Position { X = 10, Y = 20 })
-        //         .set<Velocity>({1, 2});
+        //     ecs.Entity()
+        //         .Set<Position>({10, 20})
+        //         .Set<Velocity>({1, 2});
         //
-        //     world.Entity()
-        //         .set<Position>({3, 5});
+        //     ecs.Entity()
+        //         .Set<Position>({3, 5});
         //
-        //     world.Entity()
-        //         .set<Velocity>({20, 40});
+        //     ecs.Entity()
+        //         .Set<Velocity>({20, 40});
         //
         //     int count = 0;
         //
-        //     world.each([&](Position& p, Velocity& v) {
+        //     ecs.each([&](ref Position p, ref Velocity v) {
         //         Assert.Equal(p.x, 10);
         //         Assert.Equal(p.y, 20);
         //         Assert.Equal(v.x, 1);
@@ -1343,29 +1269,30 @@ namespace Flecs.NET.Tests.Cpp
         //         count ++;
         //     });
         //
-        //     Assert.Equal(3, count);
+        //     Assert.Equal(count, 3);
         // }
         //
         // [Fact]
-        // private void 10_terms() {
-        //     using World world = World.Create();
+        // public void 10_terms()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var f = world.filter_builder<>()
-        //         .Term<TagA>()
-        //         .Term<TagB>()
-        //         .Term<TagC>()
-        //         .Term<TagD>()
-        //         .Term<TagE>()
-        //         .Term<TagF>()
-        //         .Term<TagG>()
-        //         .Term<TagH>()
-        //         .Term<TagI>()
-        //         .Term<TagJ>()
+        //     var f = ecs.filter_builder<>()
+        //         .With<TagA>()
+        //         .With<TagB>()
+        //         .With<TagC>()
+        //         .With<TagD>()
+        //         .With<TagE>()
+        //         .With<TagF>()
+        //         .With<TagG>()
+        //         .With<TagH>()
+        //         .With<TagI>()
+        //         .With<TagJ>()
         //         .build();
         //
         //     Assert.Equal(f.field_count(), 10);
         //
-        //     var e = world.Entity()
+        //     var e = ecs.Entity()
         //         .Add<TagA>()
         //         .Add<TagB>()
         //         .Add<TagC>()
@@ -1378,7 +1305,7 @@ namespace Flecs.NET.Tests.Cpp
         //         .Add<TagJ>();
         //
         //     int count = 0;
-        //     f.iter([&](flecs::iter& it) {
+        //     f.Iter((Iter it) {
         //         Assert.Equal(it.count(), 1);
         //         Assert.True(it.Entity(0) == e);
         //         Assert.Equal(it.field_count(), 10);
@@ -1389,35 +1316,36 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void 20_terms() {
-        //     using World world = World.Create();
+        // public void 20_terms()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var f = world.filter_builder<>()
-        //         .Term<TagA>()
-        //         .Term<TagB>()
-        //         .Term<TagC>()
-        //         .Term<TagD>()
-        //         .Term<TagE>()
-        //         .Term<TagF>()
-        //         .Term<TagG>()
-        //         .Term<TagH>()
-        //         .Term<TagI>()
-        //         .Term<TagJ>()
-        //         .Term<TagK>()
-        //         .Term<TagL>()
-        //         .Term<TagM>()
-        //         .Term<TagN>()
-        //         .Term<TagO>()
-        //         .Term<TagP>()
-        //         .Term<TagQ>()
-        //         .Term<TagR>()
-        //         .Term<TagS>()
-        //         .Term<TagT>()
+        //     var f = ecs.filter_builder<>()
+        //         .With<TagA>()
+        //         .With<TagB>()
+        //         .With<TagC>()
+        //         .With<TagD>()
+        //         .With<TagE>()
+        //         .With<TagF>()
+        //         .With<TagG>()
+        //         .With<TagH>()
+        //         .With<TagI>()
+        //         .With<TagJ>()
+        //         .With<TagK>()
+        //         .With<TagL>()
+        //         .With<TagM>()
+        //         .With<TagN>()
+        //         .With<TagO>()
+        //         .With<TagP>()
+        //         .With<TagQ>()
+        //         .With<TagR>()
+        //         .With<TagS>()
+        //         .With<TagT>()
         //         .build();
         //
         //     Assert.Equal(f.field_count(), 20);
         //
-        //     var e = world.Entity()
+        //     var e = ecs.Entity()
         //         .Add<TagA>()
         //         .Add<TagB>()
         //         .Add<TagC>()
@@ -1440,7 +1368,7 @@ namespace Flecs.NET.Tests.Cpp
         //         .Add<TagT>();
         //
         //     int count = 0;
-        //     f.iter([&](flecs::iter& it) {
+        //     f.Iter((Iter it) {
         //         Assert.Equal(it.count(), 1);
         //         Assert.True(it.Entity(0) == e);
         //         Assert.Equal(it.field_count(), 20);
@@ -1451,27 +1379,28 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void term_after_arg() {
-        //     using World world = World.Create();
+        // public void term_after_arg()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var e_1 = world.Entity()
+        //     var e_1 = ecs.Entity()
         //         .Add<TagA>()
         //         .Add<TagB>()
         //         .Add<TagC>();
         //
-        //     world.Entity()
+        //     ecs.Entity()
         //         .Add<TagA>()
         //         .Add<TagB>();
         //
-        //     var f = world.filter_builder<TagA, TagB>()
+        //     var f = ecs.filter_builder<TagA, TagB>()
         //         .arg(1).src(flecs::This) // dummy
-        //         .Term<TagC>()
+        //         .With<TagC>()
         //         .build();
         //
         //     Assert.Equal(f.field_count(), 3);
         //
         //     int count = 0;
-        //     f.each([&](flecs::entity e, TagA, TagB) {
+        //     f.Each((Entity e, TagA, TagB) {
         //         Assert.True(e == e_1);
         //         count ++;
         //     });
@@ -1480,17 +1409,18 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void name_arg() {
-        //     using World world = World.Create();
+        // public void name_arg()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var e = world.Entity("Foo").Set(new Position { X = 10, Y = 20 });
+        //     var e = ecs.Entity("Foo").Set<Position>({10, 20});
         //
-        //     var f = world.filter_builder<Position>()
+        //     var f = ecs.filter_builder<Position>()
         //         .arg(1).src().name("Foo")
         //         .build();
         //
         //     int count = 0;
-        //     f.iter([&](flecs::iter& it, Position* p) {
+        //     f.Iter((Iter it, Position* p) {
         //         count ++;
         //         Assert.Equal(p->x, 10);
         //         Assert.Equal(p->y, 20);
@@ -1501,18 +1431,19 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void const_in_term() {
-        //     using World world = World.Create();
+        // public void const_in_term()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Entity().Set(new Position { X = 10, Y = 20 });
+        //     ecs.Entity().Set<Position>({10, 20});
         //
-        //     var f = world.filter_builder<>()
-        //         .Term<const Position>()
+        //     var f = ecs.filter_builder<>()
+        //         .With<const Position>()
         //         .build();
         //
         //     int count = 0;
-        //     f.iter([&](flecs::iter& it) {
-        //         var p = it.field<const Position>(1);
+        //     f.Iter((Iter it) {
+        //         var p = it.Field<const Position>(1);
         //         Assert.True(it.is_readonly(1));
         //         foreach (int i in it) {
         //             count ++;
@@ -1525,41 +1456,43 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void const_optional() {
-        //     using World world = World.Create();
+        // public void const_optional()
+        // {
+        //     World ecs = World.Create();
         //
-        //  world.Entity().Set(new Position { X = 10, Y = 20 }).Add<TagA>();
-        //     world.Entity().Add<TagA>();
+        //  ecs.Entity().Set<Position>({10, 20}).Add<TagA>();
+        //     ecs.Entity().Add<TagA>();
         //
-        //     var f = world.filter_builder<TagA, const Position*>().build();
+        //     var f = ecs.filter_builder<TagA, const Position*>().build();
         //
-        //     int count = 0, set_count = 0;
-        //     f.iter([&](flecs::iter& it) {
+        //     int count = 0, Set_count = 0;
+        //     f.Iter((Iter it) {
         //         Assert.Equal(it.count(), 1);
-        //         if (it.is_set(2)) {
-        //             var p = it.field<const Position>(2);
+        //         if (it.is_Set(2)) {
+        //             var p = it.Field<const Position>(2);
         //             Assert.True(it.is_readonly(2));
         //             Assert.Equal(p->x, 10);
         //             Assert.Equal(p->y, 20);
-        //             set_count ++;
+        //             Set_count ++;
         //         }
         //         count++;
         //  });
         //
         //     Assert.Equal(2, count);
-        //     Assert.Equal(set_count, 1);
+        //     Assert.Equal(Set_count, 1);
         // }
         //
         // [Fact]
-        // private void create_w_no_template_args() {
-        //     using World world = World.Create();
+        // public void create_w_no_template_args()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var q = world.filter_builder().Term<Position>().build();
+        //     var q = ecs.filter_builder().With<Position>().build();
         //
-        //     var e1 = world.Entity().Add<Position>();
+        //     var e1 = ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1568,15 +1501,16 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void 2_terms_w_expr() {
-        //     using World world = World.Create();
+        // public void 2_terms_w_expr()
+        // {
+        //     World ecs = World.Create();
         //
-        //     var a = world.Entity("A");
-        //     var b = world.Entity("B");
+        //     var a = ecs.Entity("A");
+        //     var b = ecs.Entity("B");
         //
-        //     var e1 = world.Entity().Add(a).Add(b);
+        //     var e1 = ecs.Entity().Add(a).Add(b);
         //
-        //     var f = world.filter_builder()
+        //     var f = ecs.filter_builder()
         //         .expr("A, B")
         //         .build();
         //
@@ -1595,36 +1529,38 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void assert_on_uninitialized_term() {
+        // public void assert_on_uninitialized_term()
+        // {
         //     install_test_abort();
         //
-        //     using World world = World.Create();
+        //     World ecs = World.Create();
         //
-        //     world.Entity("A");
-        //     world.Entity("B");
+        //     ecs.Entity("A");
+        //     ecs.Entity("B");
         //
         //     test_expect_abort();
         //
-        //     var f = world.filter_builder()
+        //     var f = ecs.filter_builder()
         //         .term()
         //         .term()
         //         .build();
         // }
         //
         // [Fact]
-        // private void operator_shortcuts() {
-        //     using World world = World.Create();
+        // public void operator_shortcuts()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity a = world.Entity();
-        //     flecs::entity b = world.Entity();
-        //     flecs::entity c = world.Entity();
-        //     flecs::entity d = world.Entity();
-        //     flecs::entity e = world.Entity();
-        //     flecs::entity f = world.Entity();
-        //     flecs::entity g = world.Entity();
-        //     flecs::entity h = world.Entity();
+        //     flecs::entity a = ecs.Entity();
+        //     flecs::entity b = ecs.Entity();
+        //     flecs::entity c = ecs.Entity();
+        //     flecs::entity d = ecs.Entity();
+        //     flecs::entity e = ecs.Entity();
+        //     flecs::entity f = ecs.Entity();
+        //     flecs::entity g = ecs.Entity();
+        //     flecs::entity h = ecs.Entity();
         //
-        //     var filter = world.filter_builder()
+        //     var filter = ecs.filter_builder()
         //         .term(a).and_()
         //         .term(b).or_()
         //         .term(c)
@@ -1637,47 +1573,48 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     var t = filter.term(0);
         //     Assert.Equal(t.id(), a);
-        //     Assert.Equal(t.Oper(), flecs::And);
+        //     Assert.Equal(t.oper(), flecs::And);
         //
         //     t = filter.term(1);
         //     Assert.Equal(t.id(), b);
-        //     Assert.Equal(t.Oper(), flecs::Or);
+        //     Assert.Equal(t.oper(), flecs::Or);
         //
         //     t = filter.term(2);
         //     Assert.Equal(t.id(), c);
-        //     Assert.Equal(t.Oper(), flecs::And);
+        //     Assert.Equal(t.oper(), flecs::And);
         //
         //     t = filter.term(3);
         //     Assert.Equal(t.id(), d);
-        //     Assert.Equal(t.Oper(), flecs::Not);
+        //     Assert.Equal(t.oper(), flecs::Not);
         //
         //     t = filter.term(4);
         //     Assert.Equal(t.id(), e);
-        //     Assert.Equal(t.Oper(), flecs::Optional);
+        //     Assert.Equal(t.oper(), flecs::Optional);
         //
         //     t = filter.term(5);
         //     Assert.Equal(t.id(), f);
-        //     Assert.Equal(t.Oper(), flecs::AndFrom);
+        //     Assert.Equal(t.oper(), flecs::AndFrom);
         //
         //     t = filter.term(6);
         //     Assert.Equal(t.id(), g);
-        //     Assert.Equal(t.Oper(), flecs::OrFrom);
+        //     Assert.Equal(t.oper(), flecs::OrFrom);
         //
         //     t = filter.term(7);
         //     Assert.Equal(t.id(), h);
-        //     Assert.Equal(t.Oper(), flecs::NotFrom);
+        //     Assert.Equal(t.oper(), flecs::NotFrom);
         // }
         //
         // [Fact]
-        // private void inout_shortcuts() {
-        //     using World world = World.Create();
+        // public void inout_shortcuts()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity a = world.Entity();
-        //     flecs::entity b = world.Entity();
-        //     flecs::entity c = world.Entity();
-        //     flecs::entity d = world.Entity();
+        //     flecs::entity a = ecs.Entity();
+        //     flecs::entity b = ecs.Entity();
+        //     flecs::entity c = ecs.Entity();
+        //     flecs::entity d = ecs.Entity();
         //
-        //     var filter = world.filter_builder()
+        //     var filter = ecs.filter_builder()
         //         .term(a).in()
         //         .term(b).out()
         //         .term(c).inout()
@@ -1702,17 +1639,18 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void iter_column_w_const_as_array() {
+        // public void iter_column_w_const_as_array()
+        // {
         //     flecs::world world;
         //
         //     var f = world.filter<Position>();
         //
-        //     var e1 = world.Entity().Set(new Position { X = 10, Y = 20 });
-        //     var e2 = world.Entity().set<Position>({20, 30});
+        //     var e1 = world.Entity().Set<Position>({10, 20});
+        //     var e2 = world.Entity().Set<Position>({20, 30});
         //
         //     int count = 0;
-        //     f.iter([&](flecs::iter& it) {
-        //         const var p = it.field<Position>(1);
+        //     f.Iter((Iter it) {
+        //         const var p = it.Field<Position>(1);
         //         foreach (int i in it) {
         //             p[i].x += 1;
         //             p[i].y += 2;
@@ -1723,28 +1661,29 @@ namespace Flecs.NET.Tests.Cpp
         //
         //     Assert.Equal(2, count);
         //
-        //     const Position *p = e1.Get<Position>();
+        //     const Position *p = e1.get<Position>();
         //     Assert.Equal(p->x, 11);
         //     Assert.Equal(p->y, 22);
         //
-        //     p = e2.Get<Position>();
+        //     p = e2.get<Position>();
         //     Assert.Equal(p->x, 21);
         //     Assert.Equal(p->y, 32);
         // }
         //
         // [Fact]
-        // private void iter_column_w_const_as_ptr() {
+        // public void iter_column_w_const_as_ptr()
+        // {
         //     flecs::world world;
         //
         //     var f = world.filter<Position>();
         //
-        //     var @base = world.prefab().Set(new Position { X = 10, Y = 20 });
-        //     world.Entity().is_a(@base);
-        //     world.Entity().is_a(@base);
+        //     var base = world.prefab().Set<Position>({10, 20});
+        //     world.Entity().is_a(base);
+        //     world.Entity().is_a(base);
         //
         //     int count = 0;
-        //     f.iter([&](flecs::iter& it) {
-        //         const var p = it.field<Position>(1);
+        //     f.Iter((Iter it) {
+        //         const var p = it.Field<Position>(1);
         //         for (size_t i = 0; i < it.count(); i ++) {
         //             Assert.Equal(p->x, 10);
         //             Assert.Equal(p->y, 20);
@@ -1756,18 +1695,19 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void iter_column_w_const_deref() {
+        // public void iter_column_w_const_deref()
+        // {
         //     flecs::world world;
         //
         //     var f = world.filter<Position>();
         //
-        //     var @base = world.prefab().Set(new Position { X = 10, Y = 20 });
-        //     world.Entity().is_a(@base);
-        //     world.Entity().is_a(@base);
+        //     var base = world.prefab().Set<Position>({10, 20});
+        //     world.Entity().is_a(base);
+        //     world.Entity().is_a(base);
         //
         //     int count = 0;
-        //     f.iter([&](flecs::iter& it) {
-        //         const var p = it.field<Position>(1);
+        //     f.Iter((Iter it) {
+        //         const var p = it.Field<Position>(1);
         //         Position pv = *p;
         //         for (size_t i = 0; i < it.count(); i ++) {
         //             Assert.Equal(pv.x, 10);
@@ -1780,20 +1720,21 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_id() {
-        //     using World world = World.Create();
+        // public void with_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
-        //             .with(world.id<Position>())
-        //             .with(world.id<Velocity>())
+        //         ecs.filter_builder()
+        //             .with(ecs.id<Position>())
+        //             .with(ecs.id<Velocity>())
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>();
-        //     world.Entity().Add<Position>();
+        //     var e1 = ecs.Entity().Add<Position>().Add<Velocity>();
+        //     ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1802,22 +1743,23 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_name() {
-        //     using World world = World.Create();
+        // public void with_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Component<Velocity>();
+        //     ecs.Component<Velocity>();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with("Velocity")
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>();
-        //     world.Entity().Add<Position>();
+        //     var e1 = ecs.Entity().Add<Position>().Add<Velocity>();
+        //     ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1826,20 +1768,21 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_component() {
-        //     using World world = World.Create();
+        // public void with_component()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with<Velocity>()
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Velocity>();
-        //     world.Entity().Add<Position>();
+        //     var e1 = ecs.Entity().Add<Position>().Add<Velocity>();
+        //     ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1848,24 +1791,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_pair_id() {
-        //     using World world = World.Create();
+        // public void with_pair_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity();
-        //     flecs::entity Apples = world.Entity();
-        //     flecs::entity Pears = world.Entity();
+        //     flecs::entity Likes = ecs.Entity();
+        //     flecs::entity Apples = ecs.Entity();
+        //     flecs::entity Pears = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with(Likes, Apples)
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add(Likes, Apples);
-        //     world.Entity().Add<Position>().Add(Likes, Pears);
+        //     var e1 = ecs.Entity().Add<Position>().Add(Likes, Apples);
+        //     ecs.Entity().Add<Position>().Add(Likes, Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1874,24 +1818,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_pair_name() {
-        //     using World world = World.Create();
+        // public void with_pair_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity("Likes");
-        //     flecs::entity Apples = world.Entity("Apples");
-        //     flecs::entity Pears = world.Entity("Pears");
+        //     flecs::entity Likes = ecs.Entity("Likes");
+        //     flecs::entity Apples = ecs.Entity("Apples");
+        //     flecs::entity Pears = ecs.Entity("Pears");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with("Likes", "Apples")
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add(Likes, Apples);
-        //     world.Entity().Add<Position>().Add(Likes, Pears);
+        //     var e1 = ecs.Entity().Add<Position>().Add(Likes, Apples);
+        //     ecs.Entity().Add<Position>().Add(Likes, Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1900,24 +1845,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_pair_components() {
-        //     using World world = World.Create();
+        // public void with_pair_components()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
         //     struct Apples { };
         //     struct Pears { };
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with<Likes, Apples>()
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Likes, Apples>();
-        //     world.Entity().Add<Position>().Add<Likes, Pears>();
+        //     var e1 = ecs.Entity().Add<Position>().Add<Likes, Apples>();
+        //     ecs.Entity().Add<Position>().Add<Likes, Pears>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1926,24 +1872,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_pair_component_id() {
-        //     using World world = World.Create();
+        // public void with_pair_component_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity();
-        //     flecs::entity Pears = world.Entity();
+        //     flecs::entity Apples = ecs.Entity();
+        //     flecs::entity Pears = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with<Likes>(Apples)
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Likes>(Apples);
-        //     world.Entity().Add<Position>().Add<Likes>(Pears);
+        //     var e1 = ecs.Entity().Add<Position>().Add<Likes>(Apples);
+        //     ecs.Entity().Add<Position>().Add<Likes>(Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1952,24 +1899,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_pair_component_name() {
-        //     using World world = World.Create();
+        // public void with_pair_component_name()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity("Apples");
-        //     flecs::entity Pears = world.Entity("Pears");
+        //     flecs::entity Apples = ecs.Entity("Apples");
+        //     flecs::entity Pears = ecs.Entity("Pears");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with<Likes>("Apples")
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add<Likes>(Apples);
-        //     world.Entity().Add<Position>().Add<Likes>(Pears);
+        //     var e1 = ecs.Entity().Add<Position>().Add<Likes>(Apples);
+        //     ecs.Entity().Add<Position>().Add<Likes>(Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -1978,20 +1926,21 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void with_enum() {
-        //     using World world = World.Create();
+        // public void with_enum()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .with(Green)
         //             .build();
         //
-        //     var e1 = world.Entity().Add<Position>().Add(Green);
-        //     world.Entity().Add<Position>().Add(Red);
+        //     var e1 = ecs.Entity().Add<Position>().Add(Green);
+        //     ecs.Entity().Add<Position>().Add(Red);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e1);
         //     });
@@ -2000,20 +1949,21 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_id() {
-        //     using World world = World.Create();
+        // public void without_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
-        //             .with(world.id<Position>())
-        //             .without(world.id<Velocity>())
+        //         ecs.filter_builder()
+        //             .with(ecs.id<Position>())
+        //             .without(ecs.id<Velocity>())
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add<Velocity>();
-        //     var e2 = world.Entity().Add<Position>();
+        //     ecs.Entity().Add<Position>().Add<Velocity>();
+        //     var e2 = ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2022,22 +1972,23 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_name() {
-        //     using World world = World.Create();
+        // public void without_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Component<Velocity>();
+        //     ecs.Component<Velocity>();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
-        //             .with(world.id<Position>())
+        //         ecs.filter_builder()
+        //             .with(ecs.id<Position>())
         //             .without("Velocity")
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add<Velocity>();
-        //     var e2 = world.Entity().Add<Position>();
+        //     ecs.Entity().Add<Position>().Add<Velocity>();
+        //     var e2 = ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2046,20 +1997,21 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_component() {
-        //     using World world = World.Create();
+        // public void without_component()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .without<Velocity>()
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add<Velocity>();
-        //     var e2 = world.Entity().Add<Position>();
+        //     ecs.Entity().Add<Position>().Add<Velocity>();
+        //     var e2 = ecs.Entity().Add<Position>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2068,24 +2020,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_pair_id() {
-        //     using World world = World.Create();
+        // public void without_pair_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity();
-        //     flecs::entity Apples = world.Entity();
-        //     flecs::entity Pears = world.Entity();
+        //     flecs::entity Likes = ecs.Entity();
+        //     flecs::entity Apples = ecs.Entity();
+        //     flecs::entity Pears = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .without(Likes, Apples)
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add(Likes, Apples);
-        //     var e2 = world.Entity().Add<Position>().Add(Likes, Pears);
+        //     ecs.Entity().Add<Position>().Add(Likes, Apples);
+        //     var e2 = ecs.Entity().Add<Position>().Add(Likes, Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2094,24 +2047,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_pair_name() {
-        //     using World world = World.Create();
+        // public void without_pair_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity("Likes");
-        //     flecs::entity Apples = world.Entity("Apples");
-        //     flecs::entity Pears = world.Entity("Pears");
+        //     flecs::entity Likes = ecs.Entity("Likes");
+        //     flecs::entity Apples = ecs.Entity("Apples");
+        //     flecs::entity Pears = ecs.Entity("Pears");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .without("Likes", "Apples")
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add(Likes, Apples);
-        //     var e2 = world.Entity().Add<Position>().Add(Likes, Pears);
+        //     ecs.Entity().Add<Position>().Add(Likes, Apples);
+        //     var e2 = ecs.Entity().Add<Position>().Add(Likes, Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2120,24 +2074,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_pair_components() {
-        //     using World world = World.Create();
+        // public void without_pair_components()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
         //     struct Apples { };
         //     struct Pears { };
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .without<Likes, Apples>()
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add<Likes, Apples>();
-        //     var e2 = world.Entity().Add<Position>().Add<Likes, Pears>();
+        //     ecs.Entity().Add<Position>().Add<Likes, Apples>();
+        //     var e2 = ecs.Entity().Add<Position>().Add<Likes, Pears>();
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2146,24 +2101,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_pair_component_id() {
-        //     using World world = World.Create();
+        // public void without_pair_component_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity();
-        //     flecs::entity Pears = world.Entity();
+        //     flecs::entity Apples = ecs.Entity();
+        //     flecs::entity Pears = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .without<Likes>(Apples)
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add<Likes>(Apples);
-        //     var e2 = world.Entity().Add<Position>().Add<Likes>(Pears);
+        //     ecs.Entity().Add<Position>().Add<Likes>(Apples);
+        //     var e2 = ecs.Entity().Add<Position>().Add<Likes>(Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2172,24 +2128,25 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_pair_component_name() {
-        //     using World world = World.Create();
+        // public void without_pair_component_name()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity("Apples");
-        //     flecs::entity Pears = world.Entity("Pears");
+        //     flecs::entity Apples = ecs.Entity("Apples");
+        //     flecs::entity Pears = ecs.Entity("Pears");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .without<Likes>("Apples")
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add<Likes>(Apples);
-        //     var e2 = world.Entity().Add<Position>().Add<Likes>(Pears);
+        //     ecs.Entity().Add<Position>().Add<Likes>(Apples);
+        //     var e2 = ecs.Entity().Add<Position>().Add<Likes>(Pears);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2198,20 +2155,21 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void without_enum() {
-        //     using World world = World.Create();
+        // public void without_enum()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .without(Green)
         //             .build();
         //
-        //     world.Entity().Add<Position>().Add(Green);
-        //     var e2 = world.Entity().Add<Position>().Add(Red);
+        //     ecs.Entity().Add<Position>().Add(Green);
+        //     var e2 = ecs.Entity().Add<Position>().Add(Red);
         //
         //     int count = 0;
-        //     q.each([&](flecs::entity e) {
+        //     q.Each((Entity e) => {
         //         count ++;
         //         Assert.True(e == e2);
         //     });
@@ -2220,63 +2178,67 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void write_id() {
-        //     using World world = World.Create();
+        // public void write_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     var q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
-        //             .write(world.id<Position>())
+        //             .write(ecs.id<Position>())
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::Out);
-        //     Assert.True(q.term(1).get_first() == world.id<Position>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Position>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void write_name() {
-        //     using World world = World.Create();
+        // public void write_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Component<Position>();
+        //     ecs.Component<Position>();
         //
         //     var q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write("Position")
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::Out);
-        //     Assert.True(q.term(1).get_first() == world.id<Position>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Position>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void write_component() {
-        //     using World world = World.Create();
+        // public void write_component()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Component<Position>();
+        //     ecs.Component<Position>();
         //
         //     var q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write<Position>()
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::Out);
-        //     Assert.True(q.term(1).get_first() == world.id<Position>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Position>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void write_pair_id() {
-        //     using World world = World.Create();
+        // public void write_pair_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity();
-        //     flecs::entity Apples = world.Entity();
+        //     flecs::entity Likes = ecs.Entity();
+        //     flecs::entity Apples = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write(Likes, Apples)
         //             .build();
@@ -2288,14 +2250,15 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void write_pair_name() {
-        //     using World world = World.Create();
+        // public void write_pair_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity("Likes");
-        //     flecs::entity Apples = world.Entity("Apples");
+        //     flecs::entity Likes = ecs.Entity("Likes");
+        //     flecs::entity Apples = ecs.Entity("Apples");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write("Likes", "Apples")
         //             .build();
@@ -2307,136 +2270,144 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void write_pair_components() {
-        //     using World world = World.Create();
+        // public void write_pair_components()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
         //     struct Apples { };
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write<Likes, Apples>()
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::Out);
-        //     Assert.True(q.term(1).get_first() == world.id<Likes>());
-        //     Assert.True(q.term(1).get_second() == world.id<Apples>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Likes>());
+        //     Assert.True(q.term(1).get_second() == ecs.id<Apples>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void write_pair_component_id() {
-        //     using World world = World.Create();
+        // public void write_pair_component_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity();
+        //     flecs::entity Apples = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write<Likes>(Apples)
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::Out);
-        //     Assert.True(q.term(1).get_first() == world.id<Likes>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Likes>());
         //     Assert.True(q.term(1).get_second() == Apples);
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void write_pair_component_name() {
-        //     using World world = World.Create();
+        // public void write_pair_component_name()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity("Apples");
+        //     flecs::entity Apples = ecs.Entity("Apples");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write<Likes>("Apples")
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::Out);
-        //     Assert.True(q.term(1).get_first() == world.id<Likes>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Likes>());
         //     Assert.True(q.term(1).get_second() == Apples);
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void write_enum() {
-        //     using World world = World.Create();
+        // public void write_enum()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .write(Green)
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::Out);
-        //     Assert.True(q.term(1).get_first() == world.id<Color>());
-        //     Assert.True(q.term(1).get_second() == world.to_entity<Color>(Green));
+        //     Assert.True(q.term(1).get_first() == ecs.id<Color>());
+        //     Assert.True(q.term(1).get_second() == ecs.to_entity<Color>(Green));
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void read_id() {
-        //     using World world = World.Create();
+        // public void read_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     var q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
-        //             .read(world.id<Position>())
+        //             .read(ecs.id<Position>())
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::In);
-        //     Assert.True(q.term(1).get_first() == world.id<Position>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Position>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void read_name() {
-        //     using World world = World.Create();
+        // public void read_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Component<Position>();
+        //     ecs.Component<Position>();
         //
         //     var q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read("Position")
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::In);
-        //     Assert.True(q.term(1).get_first() == world.id<Position>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Position>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void read_component() {
-        //     using World world = World.Create();
+        // public void read_component()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.Component<Position>();
+        //     ecs.Component<Position>();
         //
         //     var q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read<Position>()
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::In);
-        //     Assert.True(q.term(1).get_first() == world.id<Position>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Position>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void read_pair_id() {
-        //     using World world = World.Create();
+        // public void read_pair_id()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity();
-        //     flecs::entity Apples = world.Entity();
+        //     flecs::entity Likes = ecs.Entity();
+        //     flecs::entity Apples = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read(Likes, Apples)
         //             .build();
@@ -2448,14 +2419,15 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void read_pair_name() {
-        //     using World world = World.Create();
+        // public void read_pair_name()
+        // {
+        //     World ecs = World.Create();
         //
-        //     flecs::entity Likes = world.Entity("Likes");
-        //     flecs::entity Apples = world.Entity("Apples");
+        //     flecs::entity Likes = ecs.Entity("Likes");
+        //     flecs::entity Apples = ecs.Entity("Apples");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read("Likes", "Apples")
         //             .build();
@@ -2467,92 +2439,97 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void read_pair_components() {
-        //     using World world = World.Create();
+        // public void read_pair_components()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
         //     struct Apples { };
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read<Likes, Apples>()
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::In);
-        //     Assert.True(q.term(1).get_first() == world.id<Likes>());
-        //     Assert.True(q.term(1).get_second() == world.id<Apples>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Likes>());
+        //     Assert.True(q.term(1).get_second() == ecs.id<Apples>());
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void read_pair_component_id() {
-        //     using World world = World.Create();
+        // public void read_pair_component_id()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity();
+        //     flecs::entity Apples = ecs.Entity();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read<Likes>(Apples)
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::In);
-        //     Assert.True(q.term(1).get_first() == world.id<Likes>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Likes>());
         //     Assert.True(q.term(1).get_second() == Apples);
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void read_pair_component_name() {
-        //     using World world = World.Create();
+        // public void read_pair_component_name()
+        // {
+        //     World ecs = World.Create();
         //
         //     struct Likes { };
-        //     flecs::entity Apples = world.Entity("Apples");
+        //     flecs::entity Apples = ecs.Entity("Apples");
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read<Likes>("Apples")
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::In);
-        //     Assert.True(q.term(1).get_first() == world.id<Likes>());
+        //     Assert.True(q.term(1).get_first() == ecs.id<Likes>());
         //     Assert.True(q.term(1).get_second() == Apples);
         //
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void read_enum() {
-        //     using World world = World.Create();
+        // public void read_enum()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> q =
-        //         world.filter_builder()
+        //         ecs.filter_builder()
         //             .with<Position>()
         //             .read(Green)
         //             .build();
         //
         //     Assert.True(q.term(1).inout() == flecs::In);
-        //     Assert.True(q.term(1).get_first() == world.id<Color>());
-        //     Assert.True(q.term(1).get_second() == world.to_entity<Color>(Green));
+        //     Assert.True(q.term(1).get_first() == ecs.id<Color>());
+        //     Assert.True(q.term(1).get_second() == ecs.to_entity<Color>(Green));
         //     Assert.True(q.term(1).get_src() == 0);
         // }
         //
         // [Fact]
-        // private void assign_after_init() {
-        //     using World world = World.Create();
+        // public void assign_after_init()
+        // {
+        //     World ecs = World.Create();
         //
         //     flecs::filter<> f;
-        //     flecs::filter_builder<> fb = world.filter_builder();
+        //     flecs::filter_builder<> fb = ecs.filter_builder();
         //     fb.with<Position>();
         //     f = fb.build();
         //
-        //     flecs::entity e1 = world.Entity().Set(new Position { X = 10, Y = 20 });
+        //     flecs::entity e1 = ecs.Entity().Set<Position>({10, 20});
         //
         //     int count = 0;
-        //     f.each([&](flecs::entity e) {
+        //     f.Each((Entity e) => {
         //         Assert.True(e == e1);
         //         count ++;
         //     });
@@ -2561,18 +2538,19 @@ namespace Flecs.NET.Tests.Cpp
         // }
         //
         // [Fact]
-        // private void iter_w_stage() {
-        //     using World world = World.Create();
+        // public void iter_w_stage()
+        // {
+        //     World ecs = World.Create();
         //
-        //     world.set_stage_count(2);
-        //     flecs::world stage = world.get_stage(1);
+        //     ecs.Set_stage_count(2);
+        //     flecs::world stage = ecs.get_stage(1);
         //
-        //     var e1 = world.Entity().Add<Position>();
+        //     var e1 = ecs.Entity().Add<Position>();
         //
-        //     var q = world.filter<Position>();
+        //     var q = ecs.filter<Position>();
         //
         //     int count = 0;
-        //     q.each(stage, [&](flecs::iter& it, size_t i, Position&) {
+        //     q.each(stage, [&](flecs::iter& it, size_t i, ref Position) {
         //         Assert.True(it.world() == stage);
         //         Assert.True(it.Entity(i) == e1);
         //         count ++;

--- a/src/Flecs.NET.Tests/Helpers.cs
+++ b/src/Flecs.NET.Tests/Helpers.cs
@@ -83,12 +83,26 @@ public struct Pod
         {
             Ctor = (ref CtorData ctorData) =>
             {
-                ctorData.Get<Pod>().CtorInvoked++;
-                ctorData.Get<Pod>().Value = 10;
+                ref Pod data = ref ctorData.Get<Pod>();
+                //...
             },
-            Dtor = (ref DtorData dtorData) => { dtorData.Get<Pod>().DtorInvoked++; },
-            Move = (ref MoveData moveData) => { },
-            Copy = (ref CopyData copyData) => { }
+            Dtor = (ref DtorData dtorData) =>
+            {
+                ref Pod data = ref dtorData.Get<Pod>();
+                //...
+            },
+            Move = (ref MoveData moveData) =>
+            {
+                ref Pod src = ref moveData.Src<Pod>();
+                ref Pod dest = ref moveData.Dst<Pod>();
+                //...
+            },
+            Copy = (ref CopyData copyData) =>
+            {
+                ref Pod src = ref copyData.Src<Pod>();
+                ref Pod dest = ref copyData.Dst<Pod>();
+                //...
+            }
         });
     }
 };

--- a/src/Flecs.NET/Core/BindingContext.cs
+++ b/src/Flecs.NET/Core/BindingContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Flecs.NET.Polyfill;
 using Flecs.NET.Utilities;
@@ -10,12 +9,12 @@ namespace Flecs.NET.Core
     /// <summary>
     ///     A static class holding methods and types for binding contexts.
     /// </summary>
-    public static unsafe class BindingContext
+    public static unsafe partial class BindingContext
     {
         private static readonly BindingContextCleanup _ = new BindingContextCleanup();
 
-        internal static readonly byte* DefaultSeparator;
-        internal static readonly byte* DefaultRootSeparator;
+        internal static readonly byte* DefaultSeparator = (byte*)Marshal.StringToHGlobalAnsi(".");
+        internal static readonly byte* DefaultRootSeparator = (byte*)Marshal.StringToHGlobalAnsi("::");
 
 #if NET5_0_OR_GREATER
         internal static readonly IntPtr ObserverIterPointer =
@@ -54,69 +53,60 @@ namespace Flecs.NET.Core
         internal static readonly IntPtr OsApiAbortPointer =
             (IntPtr)(delegate* unmanaged<void>)&OsApiAbort;
 #else
-        internal static readonly IntPtr ObserverIterPointer;
-        internal static readonly IntPtr RoutineIterPointer;
+        internal static readonly IntPtr ObserverIterPointer =
+            Marshal.GetFunctionPointerForDelegate(ObserverIterReference = ObserverIter);
 
-        internal static readonly IntPtr ObserverEachEntityPointer;
-        internal static readonly IntPtr RoutineEachEntityPointer;
+        internal static readonly IntPtr RoutineIterPointer =
+            Marshal.GetFunctionPointerForDelegate(RoutineIterReference = RoutineIter);
 
-        internal static readonly IntPtr ObserverEachIndexPointer;
-        internal static readonly IntPtr RoutineEachIndexPointer;
+        internal static readonly IntPtr ObserverEachEntityPointer =
+            Marshal.GetFunctionPointerForDelegate(ObserverEachEntityReference = ObserverEachEntity);
 
-        internal static readonly IntPtr WorldContextFreePointer;
-        internal static readonly IntPtr ObserverContextFreePointer;
-        internal static readonly IntPtr RoutineContextFreePointer;
-        internal static readonly IntPtr QueryContextFreePointer;
+        internal static readonly IntPtr RoutineEachEntityPointer =
+            Marshal.GetFunctionPointerForDelegate(RoutineEachEntityReference = RoutineEachEntity);
 
-        internal static readonly IntPtr TypeHooksContextFreePointer;
+        internal static readonly IntPtr ObserverEachIndexPointer =
+            Marshal.GetFunctionPointerForDelegate(ObserverEachIndexReference = ObserverEachIndex);
 
-        internal static readonly IntPtr OsApiAbortPointer;
+        internal static readonly IntPtr RoutineEachIndexPointer =
+            Marshal.GetFunctionPointerForDelegate(RoutineEachIndexReference = RoutineEachIndex);
 
-        private static readonly Ecs.IterAction ObserverIterReference = ObserverIter;
-        private static readonly Ecs.IterAction RoutineIterReference = RoutineIter;
+        internal static readonly IntPtr WorldContextFreePointer =
+            Marshal.GetFunctionPointerForDelegate(WorldContextFreeReference = WorldContextFree);
 
-        private static readonly Ecs.IterAction ObserverEachEntityReference = ObserverEachEntity;
-        private static readonly Ecs.IterAction RoutineEachEntityReference = RoutineEachEntity;
+        internal static readonly IntPtr ObserverContextFreePointer =
+            Marshal.GetFunctionPointerForDelegate(ObserverContextFreeReference = ObserverContextFree);
 
-        private static readonly Ecs.IterAction ObserverEachIndexReference = ObserverEachIndex;
-        private static readonly Ecs.IterAction RoutineEachIndexReference = RoutineEachIndex;
+        internal static readonly IntPtr RoutineContextFreePointer =
+            Marshal.GetFunctionPointerForDelegate(RoutineContextFreeReference = RoutineContextFree);
 
-        private static readonly Ecs.ContextFree WorldContextFreeReference = WorldContextFree;
-        private static readonly Ecs.ContextFree ObserverContextFreeReference = ObserverContextFree;
-        private static readonly Ecs.ContextFree RoutineContextFreeReference = RoutineContextFree;
-        private static readonly Ecs.ContextFree QueryContextFreeReference = QueryContextFree;
+        internal static readonly IntPtr QueryContextFreePointer =
+            Marshal.GetFunctionPointerForDelegate(QueryContextFreeReference = QueryContextFree);
 
-        private static readonly Ecs.ContextFree TypeHooksContextFreeReference = TypeHooksContextFree;
+        internal static readonly IntPtr TypeHooksContextFreePointer=
+            Marshal.GetFunctionPointerForDelegate(TypeHooksContextFreeReference = TypeHooksContextFree);
 
-        private static readonly Action OsApiAbortReference = OsApiAbort;
+        internal static readonly IntPtr OsApiAbortPointer =
+            Marshal.GetFunctionPointerForDelegate(OsApiAbortReference = OsApiAbort);
+
+        private static readonly Ecs.IterAction ObserverIterReference;
+        private static readonly Ecs.IterAction RoutineIterReference;
+
+        private static readonly Ecs.IterAction ObserverEachEntityReference;
+        private static readonly Ecs.IterAction RoutineEachEntityReference;
+
+        private static readonly Ecs.IterAction ObserverEachIndexReference;
+        private static readonly Ecs.IterAction RoutineEachIndexReference;
+
+        private static readonly Ecs.ContextFree WorldContextFreeReference;
+        private static readonly Ecs.ContextFree ObserverContextFreeReference;
+        private static readonly Ecs.ContextFree RoutineContextFreeReference;
+        private static readonly Ecs.ContextFree QueryContextFreeReference;
+
+        private static readonly Ecs.ContextFree TypeHooksContextFreeReference;
+
+        private static readonly Action OsApiAbortReference;
 #endif
-
-        [SuppressMessage("Usage", "CA1810")]
-        static BindingContext()
-        {
-            DefaultSeparator = (byte*)Marshal.StringToHGlobalAnsi(".");
-            DefaultRootSeparator = (byte*)Marshal.StringToHGlobalAnsi("::");
-
-#if !NET5_0_OR_GREATER
-            ObserverIterPointer = Marshal.GetFunctionPointerForDelegate(ObserverIterReference);
-            RoutineIterPointer = Marshal.GetFunctionPointerForDelegate(RoutineIterReference);
-
-            ObserverEachEntityPointer = Marshal.GetFunctionPointerForDelegate(ObserverEachEntityReference);
-            RoutineEachEntityPointer = Marshal.GetFunctionPointerForDelegate(RoutineEachEntityReference);
-
-            ObserverEachIndexPointer = Marshal.GetFunctionPointerForDelegate(ObserverEachIndexReference);
-            RoutineEachIndexPointer = Marshal.GetFunctionPointerForDelegate(RoutineEachIndexReference);
-
-            WorldContextFreePointer = Marshal.GetFunctionPointerForDelegate(WorldContextFreeReference);
-            ObserverContextFreePointer = Marshal.GetFunctionPointerForDelegate(ObserverContextFreeReference);
-            RoutineContextFreePointer = Marshal.GetFunctionPointerForDelegate(RoutineContextFreeReference);
-            QueryContextFreePointer = Marshal.GetFunctionPointerForDelegate(QueryContextFreeReference);
-
-            TypeHooksContextFreePointer = Marshal.GetFunctionPointerForDelegate(TypeHooksContextFreeReference);
-
-            OsApiAbortPointer = Marshal.GetFunctionPointerForDelegate(OsApiAbortReference);
-#endif
-        }
 
         [UnmanagedCallersOnly]
         private static void ObserverIter(ecs_iter_t* iter)
@@ -266,27 +256,29 @@ namespace Flecs.NET.Core
             dest = default;
         }
 
-        internal static Callback AllocCallback<T>(T? callback) where T : Delegate
+        internal static Callback AllocCallback<T>(T? callback, bool storePtr = true) where T : Delegate
         {
-            return callback == null
-                ? new Callback(IntPtr.Zero, IntPtr.Zero)
-                : new Callback(Marshal.GetFunctionPointerForDelegate(callback), (IntPtr)GCHandle.Alloc(callback));
+            if (callback == null)
+                return default;
+
+            IntPtr funcPtr = storePtr ? Marshal.GetFunctionPointerForDelegate(callback) : IntPtr.Zero;
+            return new Callback(funcPtr, GCHandle.Alloc(callback));
         }
 
-        internal static void SetCallback<T>(ref Callback dest, T? callback) where T : Delegate
+        internal static void SetCallback<T>(ref Callback dest, T? callback, bool storePtr = true) where T : Delegate
         {
-            if (dest.GcHandle != IntPtr.Zero)
+            if (dest.GcHandle != default)
                 FreeCallback(ref dest);
 
-            dest = AllocCallback(callback);
+            dest = AllocCallback(callback, storePtr);
         }
 
         internal struct Callback
         {
             public IntPtr Function;
-            public IntPtr GcHandle;
+            public GCHandle GcHandle;
 
-            public Callback(IntPtr function, IntPtr gcHandle)
+            public Callback(IntPtr function, GCHandle gcHandle)
             {
                 Function = function;
                 GcHandle = gcHandle;

--- a/src/Flecs.NET/Core/Ecs.cs
+++ b/src/Flecs.NET/Core/Ecs.cs
@@ -20,12 +20,12 @@ namespace Flecs.NET.Core
         [Conditional("DEBUG")]
         internal static void Assert(bool condition, string message = "")
         {
-            Debug.Assert(condition, "[Flecs.NET Assertion]: " + message);
+            Debug.Assert(condition, $"[Flecs.NET Assertion]: {message}");
         }
 
         internal static void Error(string message)
         {
-            Debug.Fail("[Flecs.NET Error]: " + message);
+            Debug.Fail($"[Flecs.NET Error]: {message}");
         }
     }
 
@@ -183,11 +183,6 @@ namespace Flecs.NET.Core
         ///     Each entity callback.
         /// </summary>
         public delegate void EachEntityCallback(Entity entity);
-
-        /// <summary>
-        ///     Each entity callback.
-        /// </summary>
-        public delegate void EachEntityCallback<T>(Entity entity, ref T comp);
 
         /// <summary>
         ///     Each id callback.

--- a/src/Flecs.NET/Core/Filter.cs
+++ b/src/Flecs.NET/Core/Filter.cs
@@ -24,7 +24,7 @@ namespace Flecs.NET.Core
         /// <summary>
         ///     A pointer to the filter.
         /// </summary>
-        public ecs_filter_t* FilterPtr => _isOwned ? (ecs_filter_t*)Unsafe.AsPointer(ref _filter) : _filterPtr;
+        public ecs_filter_t* Handle => _isOwned ? (ecs_filter_t*)Unsafe.AsPointer(ref _filter) : _filterPtr;
 
         /// <summary>
         ///     Creates a filter.
@@ -87,7 +87,7 @@ namespace Flecs.NET.Core
         {
             fixed (ecs_filter_t* mFilter = &_filter)
             {
-                if (mFilter == FilterPtr && FilterPtr != null)
+                if (mFilter == Handle && Handle != null)
                     ecs_filter_fini(mFilter);
             }
         }
@@ -98,7 +98,7 @@ namespace Flecs.NET.Core
         /// <returns></returns>
         public Entity Entity()
         {
-            return new Entity(World, ecs_get_entity(FilterPtr));
+            return new Entity(World, ecs_get_entity(Handle));
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Flecs.NET.Core
         /// <returns></returns>
         public string Str()
         {
-            return NativeString.GetStringAndFree(ecs_filter_str(World, FilterPtr));
+            return NativeString.GetStringAndFree(ecs_filter_str(World, Handle));
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Flecs.NET.Core
         /// <returns></returns>
         public IterIterable Iter()
         {
-            return new IterIterable(ecs_filter_iter(World, FilterPtr), _next, _nextInstanced);
+            return new IterIterable(ecs_filter_iter(World, Handle), _next, _nextInstanced);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace Flecs.NET.Core
         /// <param name="func"></param>
         public void Iter(Ecs.IterCallback func)
         {
-            ecs_iter_t iter = ecs_filter_iter(World, FilterPtr);
+            ecs_iter_t iter = ecs_filter_iter(World, Handle);
             while (ecs_filter_next(&iter) == 1)
                 Invoker.Iter(&iter, func);
         }
@@ -145,7 +145,7 @@ namespace Flecs.NET.Core
         /// <param name="func"></param>
         public void Each(Ecs.EachEntityCallback func)
         {
-            ecs_iter_t iter = ecs_filter_iter(World, FilterPtr);
+            ecs_iter_t iter = ecs_filter_iter(World, Handle);
             while (ecs_filter_next_instanced(&iter) == 1)
                 Invoker.Each(&iter, func);
         }
@@ -156,7 +156,7 @@ namespace Flecs.NET.Core
         /// <param name="func"></param>
         public void Each(Ecs.EachIndexCallback func)
         {
-            ecs_iter_t iter = ecs_filter_iter(World, FilterPtr);
+            ecs_iter_t iter = ecs_filter_iter(World, Handle);
             while (ecs_filter_next_instanced(&iter) == 1)
                 Invoker.Each(&iter, func);
         }

--- a/src/Flecs.NET/Core/Invoker.cs
+++ b/src/Flecs.NET/Core/Invoker.cs
@@ -7,7 +7,7 @@ namespace Flecs.NET.Core
     /// <summary>
     ///     A static class for holding callback invokers.
     /// </summary>
-    public static unsafe class Invoker
+    public static unsafe partial class Invoker
     {
         /// <summary>
         ///     Invokes an iter callback using a delegate.
@@ -29,12 +29,12 @@ namespace Flecs.NET.Core
         /// <param name="callback"></param>
         public static void Each(ecs_iter_t* iter, Ecs.EachEntityCallback callback)
         {
-            Macros.TableLock(iter->world, iter->table);
-
             ecs_world_t* world = iter->world;
             int count = iter->count;
 
             Ecs.Assert(count > 0, "No entities returned, use Iter() instead.");
+
+            Macros.TableLock(iter->world, iter->table);
 
             for (int i = 0; i < count; i++)
                 callback(new Entity(world, iter->entities[i]));
@@ -47,33 +47,9 @@ namespace Flecs.NET.Core
         /// </summary>
         /// <param name="iter"></param>
         /// <param name="callback"></param>
-        public static void Each<T>(ecs_iter_t* iter, Ecs.EachEntityCallback<T> callback)
-        {
-            Macros.TableLock(iter->world, iter->table);
-
-            ecs_world_t* world = iter->world;
-            int count = iter->count;
-
-            Ecs.Assert(count > 0, "No entities returned, use Iter() instead.");
-            Core.Iter.AssertFieldId<T>(iter, 1);
-
-            for (int i = 0; i < count; i++)
-                callback(new Entity(world, iter->entities[i]), ref Managed.GetTypeRef<T>(iter->ptrs[0], i));
-
-            Macros.TableUnlock(iter->world, iter->table);
-        }
-
-        /// <summary>
-        ///     Invokes an each callback using a delegate.
-        /// </summary>
-        /// <param name="iter"></param>
-        /// <param name="callback"></param>
         public static void Each(ecs_iter_t* iter, Ecs.EachIndexCallback callback)
         {
-            int count = iter->count;
-
-            if (count == 0)
-                count = 1;
+            int count = iter->count == 0 ? 1 : iter->count;
 
             Iter it = new Iter(iter);
 

--- a/src/Flecs.NET/Core/Iter.cs
+++ b/src/Flecs.NET/Core/Iter.cs
@@ -411,9 +411,13 @@ namespace Flecs.NET.Core
         {
             ulong termId = ecs_field_id(iter, index);
             ulong typeId = Type<T>.Id(iter->world);
-            Ecs.Assert(
-                termId == typeId || ecs_get_typeid(iter->world, termId) == typeId,
-                nameof(ECS_COLUMN_TYPE_MISMATCH));
+
+            if (termId == typeId || ecs_get_typeid(iter->world, termId) == typeId)
+                return;
+
+            Entity expected = new Entity(iter->world, termId);
+            Entity actual = new Entity(iter->world, typeId);
+            Ecs.Error($"Type argument mismatch at term index {index}.\nExpected Term: {expected}\nActual Term: {actual}");
         }
 
         /// <summary>

--- a/src/Flecs.NET/Core/ObserverBuilder.cs
+++ b/src/Flecs.NET/Core/ObserverBuilder.cs
@@ -9,10 +9,10 @@ namespace Flecs.NET.Core
     public unsafe struct ObserverBuilder : IDisposable
     {
         private ecs_world_t* _world;
-        private int _eventCount;
 
         internal ecs_observer_desc_t ObserverDesc;
         internal BindingContext.ObserverContext ObserverContext;
+        internal int EventCount;
 
         /// <summary>
         ///     A reference to the world.
@@ -32,8 +32,8 @@ namespace Flecs.NET.Core
         {
             ObserverDesc = default;
             ObserverContext = default;
+            EventCount = default;
             _world = world;
-            _eventCount = default;
         }
 
         /// <summary>
@@ -52,10 +52,10 @@ namespace Flecs.NET.Core
         /// <exception cref="InvalidOperationException"></exception>
         public ref ObserverBuilder Event(ulong @event)
         {
-            if (_eventCount >= 8)
+            if (EventCount >= 8)
                 throw new InvalidOperationException();
 
-            ObserverDesc.events[_eventCount++] = @event;
+            ObserverDesc.events[EventCount++] = @event;
             return ref this;
         }
 

--- a/src/Flecs.NET/Core/Query.cs
+++ b/src/Flecs.NET/Core/Query.cs
@@ -13,8 +13,6 @@ namespace Flecs.NET.Core
         private ecs_world_t* _world;
         private ecs_query_t* _handle;
 
-        internal BindingContext.QueryContext QueryContext;
-
         /// <summary>
         ///     A reference to the world.
         /// </summary>
@@ -39,7 +37,6 @@ namespace Flecs.NET.Core
             QueryBuilder queryBuilder = default,
             string name = "")
         {
-            QueryContext = queryBuilder.QueryContext;
             _world = world;
 
             BindingContext.QueryContext* queryContext = Memory.Alloc<BindingContext.QueryContext>(1);
@@ -47,7 +44,7 @@ namespace Flecs.NET.Core
 
             ecs_query_desc_t* queryDesc = &queryBuilder.QueryDesc;
             queryDesc->filter = filterBuilder.Desc;
-            queryDesc->filter.terms_buffer = (ecs_term_t*)filterBuilder.Terms.Data;
+            queryDesc->filter.terms_buffer = filterBuilder.Terms.Data;
             queryDesc->filter.terms_buffer_count = filterBuilder.Terms.Count;
             queryDesc->binding_ctx = queryContext;
             queryDesc->binding_ctx_free = BindingContext.QueryContextFreePointer;
@@ -78,7 +75,6 @@ namespace Flecs.NET.Core
         /// <param name="query"></param>
         public Query(ecs_world_t* world, ecs_query_t* query = null)
         {
-            QueryContext = default;
             _world = world;
             _handle = query;
         }
@@ -100,7 +96,6 @@ namespace Flecs.NET.Core
                 return;
 
             ecs_query_fini(Handle);
-            QueryContext.Dispose();
             World = null;
             Handle = null;
         }

--- a/src/Flecs.NET/Core/Routine.cs
+++ b/src/Flecs.NET/Core/Routine.cs
@@ -48,6 +48,7 @@ namespace Flecs.NET.Core
             _entity = default;
 
             InitRoutine(
+                true,
                 BindingContext.RoutineIterPointer,
                 ref callback,
                 ref world,
@@ -79,6 +80,7 @@ namespace Flecs.NET.Core
             _entity = default;
 
             InitRoutine(
+                true,
                 BindingContext.RoutineEachEntityPointer,
                 ref callback,
                 ref world,
@@ -110,6 +112,7 @@ namespace Flecs.NET.Core
             _entity = default;
 
             InitRoutine(
+                true,
                 BindingContext.RoutineEachIndexPointer,
                 ref callback,
                 ref world,
@@ -130,7 +133,8 @@ namespace Flecs.NET.Core
             _entity = new Entity(world, entity);
         }
 
-        private void InitRoutine<T>(
+        internal ref Routine InitRoutine<T>(
+            bool storeFunctionPointer,
             IntPtr internalCallback,
             ref T? userCallback,
             ref ecs_world_t* world,
@@ -169,7 +173,7 @@ namespace Flecs.NET.Core
             BindingContext.RoutineContext* routineContext = Memory.Alloc<BindingContext.RoutineContext>(1);
             routineContext[0] = routineBuilder.RoutineContext;
             routineContext->QueryContext = queryBuilder.QueryContext;
-            BindingContext.SetCallback(ref routineContext->Iterator, userCallback);
+            BindingContext.SetCallback(ref routineContext->Iterator, userCallback, storeFunctionPointer);
 
             ecs_system_desc_t* routineDesc =
                 (ecs_system_desc_t*)Unsafe.AsPointer(ref routineBuilder.RoutineDesc);
@@ -187,6 +191,8 @@ namespace Flecs.NET.Core
 
             _entity = new Entity(world, ecs_system_init(world, routineDesc));
             filterBuilder.Dispose();
+
+            return ref this;
         }
 
         /// <summary>

--- a/src/Flecs.NET/Core/Snapshot.cs
+++ b/src/Flecs.NET/Core/Snapshot.cs
@@ -54,7 +54,7 @@ namespace Flecs.NET.Core
             if (Handle != null)
                 ecs_snapshot_free(Handle);
 
-            ecs_iter_t it = ecs_filter_iter(World, filter.FilterPtr);
+            ecs_iter_t it = ecs_filter_iter(World, filter.Handle);
             Handle = ecs_snapshot_take_w_iter(&it);
         }
 

--- a/src/Flecs.NET/Core/TypeHooks.cs
+++ b/src/Flecs.NET/Core/TypeHooks.cs
@@ -63,61 +63,49 @@ namespace Flecs.NET.Core
 #if NET5_0_OR_GREATER
         internal static readonly IntPtr NormalCtorPointer =
             (IntPtr)(delegate* unmanaged<void*, int, ecs_type_info_t*, void>)&NormalCtor;
-
         internal static readonly IntPtr NormalDtorPointer =
             (IntPtr)(delegate* unmanaged<void*, int, ecs_type_info_t*, void>)&NormalDtor;
-
         internal static readonly IntPtr NormalMovePointer =
             (IntPtr)(delegate* unmanaged<void*, void*, int, ecs_type_info_t*, void>)&NormalMove;
-
         internal static readonly IntPtr NormalCopyPointer =
             (IntPtr)(delegate* unmanaged<void*, void*, int, ecs_type_info_t*, void>)&NormalCopy;
 
         internal static readonly IntPtr GcHandleCtorPointer =
             (IntPtr)(delegate* unmanaged<void*, int, ecs_type_info_t*, void>)&GcHandleCtor;
-
         internal static readonly IntPtr GcHandleDtorPointer =
             (IntPtr)(delegate* unmanaged<void*, int, ecs_type_info_t*, void>)&GcHandleDtor;
-
         internal static readonly IntPtr GcHandleMovePointer =
             (IntPtr)(delegate* unmanaged<void*, void*, int, ecs_type_info_t*, void>)&GcHandleMove;
-
         internal static readonly IntPtr GcHandleCopyPointer =
             (IntPtr)(delegate* unmanaged<void*, void*, int, ecs_type_info_t*, void>)&GcHandleCopy;
 #else
-        internal static readonly IntPtr NormalCtorPointer;
-        internal static readonly IntPtr NormalDtorPointer;
-        internal static readonly IntPtr NormalMovePointer;
-        internal static readonly IntPtr NormalCopyPointer;
+        internal static readonly IntPtr NormalCtorPointer =
+            Marshal.GetFunctionPointerForDelegate(NormalCtorReference = NormalCtor);
+        internal static readonly IntPtr NormalDtorPointer =
+            Marshal.GetFunctionPointerForDelegate(NormalDtorReference = NormalDtor);
+        internal static readonly IntPtr NormalMovePointer =
+            Marshal.GetFunctionPointerForDelegate(NormalMoveReference = NormalMove);
+        internal static readonly IntPtr NormalCopyPointer =
+            Marshal.GetFunctionPointerForDelegate(NormalCopyReference = NormalCopy);
 
-        internal static readonly IntPtr GcHandleCtorPointer;
-        internal static readonly IntPtr GcHandleDtorPointer;
-        internal static readonly IntPtr GcHandleMovePointer;
-        internal static readonly IntPtr GcHandleCopyPointer;
+        internal static readonly IntPtr GcHandleCtorPointer =
+            Marshal.GetFunctionPointerForDelegate(GcHandleCtorReference = GcHandleCtor);
+        internal static readonly IntPtr GcHandleDtorPointer =
+            Marshal.GetFunctionPointerForDelegate(GcHandleDtorReference = GcHandleDtor);
+        internal static readonly IntPtr GcHandleMovePointer =
+            Marshal.GetFunctionPointerForDelegate(GcHandleMoveReference = GcHandleMove);
+        internal static readonly IntPtr GcHandleCopyPointer =
+            Marshal.GetFunctionPointerForDelegate(GcHandleCopyReference = GcHandleCopy);
 
-        private static readonly UnmanagedCtor NormalCtorReference = NormalCtor;
-        private static readonly UnmanagedDtor NormalDtorReference = NormalDtor;
-        private static readonly UnmanagedMove NormalMoveReference = NormalMove;
-        private static readonly UnmanagedCopy NormalCopyReference = NormalCopy;
+        private static readonly UnmanagedCtor NormalCtorReference;
+        private static readonly UnmanagedDtor NormalDtorReference;
+        private static readonly UnmanagedMove NormalMoveReference;
+        private static readonly UnmanagedCopy NormalCopyReference;
 
-        private static readonly UnmanagedCtor GcHandleCtorReference = GcHandleCtor;
-        private static readonly UnmanagedDtor GcHandleDtorReference = GcHandleDtor;
-        private static readonly UnmanagedMove GcHandleMoveReference = GcHandleMove;
-        private static readonly UnmanagedCopy GcHandleCopyReference = GcHandleCopy;
-
-        [SuppressMessage("Usage", "CA1810")]
-        static TypeHooks()
-        {
-            NormalCtorPointer = Marshal.GetFunctionPointerForDelegate(NormalCtorReference);
-            NormalDtorPointer = Marshal.GetFunctionPointerForDelegate(NormalDtorReference);
-            NormalMovePointer = Marshal.GetFunctionPointerForDelegate(NormalMoveReference);
-            NormalCopyPointer = Marshal.GetFunctionPointerForDelegate(NormalCopyReference);
-
-            GcHandleCtorPointer = Marshal.GetFunctionPointerForDelegate(GcHandleCtorReference);
-            GcHandleDtorPointer = Marshal.GetFunctionPointerForDelegate(GcHandleDtorReference);
-            GcHandleMovePointer = Marshal.GetFunctionPointerForDelegate(GcHandleMoveReference);
-            GcHandleCopyPointer = Marshal.GetFunctionPointerForDelegate(GcHandleCopyReference);
-        }
+        private static readonly UnmanagedCtor GcHandleCtorReference;
+        private static readonly UnmanagedDtor GcHandleDtorReference;
+        private static readonly UnmanagedMove GcHandleMoveReference;
+        private static readonly UnmanagedCopy GcHandleCopyReference;
 #endif
 
         [UnmanagedCallersOnly]

--- a/src/Flecs.NET/Core/World.cs
+++ b/src/Flecs.NET/Core/World.cs
@@ -8,7 +8,7 @@ namespace Flecs.NET.Core
     ///     The world is the container of all ECS data and systems. If the world is deleted, all data in the world will be
     ///     deleted as well.
     /// </summary>
-    public unsafe struct World : IDisposable, IEquatable<World>
+    public unsafe partial struct World : IDisposable, IEquatable<World>
     {
         private ecs_world_t* _handle;
         private bool _owned;

--- a/src/Flecs.NET/Flecs.NET.csproj
+++ b/src/Flecs.NET/Flecs.NET.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>3.2.7-build.9</Version>
+        <Version>3.2.7-build.10</Version>
         <Title Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Debug</Title>
         <Title Condition="'$(Configuration)' == 'Release'">Flecs.NET.Release</Title>
         <Authors>BeanCheeseBurrito</Authors>
@@ -43,8 +43,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+
         <ProjectReference Include="..\Flecs.NET.Bindings\Flecs.NET.Bindings.csproj" />
         <ProjectReference Include="..\Flecs.NET.Native\Flecs.NET.Native.csproj" />
+        <ProjectReference Include="..\Flecs.NET.Codegen\Flecs.NET.Codegen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR adds a source generator that creates generic iteration callbacks for filters, rules, queries, observers, and routines with the goal of reducing the amount of boilerplate code needed construct queries.

```cs
// Before 16 lines
Routine routine = world.Routine(
    filter: world.FilterBuilder()
        .With<Position>()
        .With<Velocity>(),
    callback: (Iter it) =>
    {
        Column<Position> p = it.Field<Position>(1);
        Column<Velocity> v = it.Field<Velocity>(2);

        foreach (int i in it)
        {
            p[i].X += v[i].X;
            p[i].Y += v[i].Y;
        }
    }
);

// After 8 lines
Routine routine = world.Routine(
    filter: world.FilterBuilder<Position, Velocity>(),
    callback: (ref Position p, ref Velocity v) =>
    {
        p.X += v.X;
        p.Y += v.Y;
    }
);
```

The following callback signatures are available and support up to 16 type arguments:
```cs
// (Comps...)
Routine routine = world.Routine(
    filter: world.FilterBuilder<Position, Velocity>(),
    callback: (ref Position p, ref Velocity v) => { }
);

// (Entity, Comps...)
Routine routine = world.Routine(
    filter: world.FilterBuilder<Position, Velocity>(),
    callback: (Entity e, ref Position p, ref Velocity v) => { }
);

// (Iter, Index, Comps...)
Routine routine = world.Routine(
    filter: world.FilterBuilder<Position, Velocity>(),
    callback: (Iter it, int i, ref Position p, ref Velocity v) => { }
);

// (Iter, Comps...)
Routine routine = world.Routine(
    filter: world.FilterBuilder<Position, Velocity>(),
    callback: (Iter it, Column<Position> p, Column<Velocity> v) => { }
);
```