### PR TITLE
Add run callbacks/tests and refactor iterable apis

### DIFF
--- a/src/Flecs.NET.Codegen/Generator.cs
+++ b/src/Flecs.NET.Codegen/Generator.cs
@@ -36,8 +36,7 @@ namespace Flecs.NET.Codegen
                     {GenerateEcsExtensions()}
                     {GenerateInvokerExtensions()}
                     {GenerateBindingContextExtensions()}
-                    {GenerateQueryExtensions()}
-                    {GenerateIterIterableExtensions()}
+                    {GenerateIterableExtensions()}
                     {GenerateObserverExtensions()}
                     {GenerateRoutineExtensions()}
                 }}
@@ -51,9 +50,8 @@ namespace Flecs.NET.Codegen
             return $@"
                 public unsafe partial struct World
                 {{
-                    {GenerateIterableFactoryExtensions()}
+                    {GenerateBuilderFactoryExtensions()}
                     {GenerateWorldEachCallbackFunctions()}
-                    {GenerateWorldEachEntityCallbackFunction()}
                 }}
             ";
         }
@@ -87,11 +85,6 @@ namespace Flecs.NET.Codegen
                 {{
                     {GenerateIterInvokers()}
                     {GenerateEachInvokers()}
-                    {GenerateEachEntityInvokers()}
-                    {GenerateEachIndexInvokers()}
-                    {GenerateFindInvokers()}
-                    {GenerateFindEntityInvokers()}
-                    {GenerateFindIndexInvokers()}
                     {GenerateGetPointers()}
                     {GenerateEnsurePointers()}
                     {GenerateReadInvokers()}
@@ -101,7 +94,7 @@ namespace Flecs.NET.Codegen
             ";
         }
 
-        private static string GenerateQueryExtensions()
+        private static string GenerateIterableExtensions()
         {
             StringBuilder str = new StringBuilder();
 
@@ -115,15 +108,15 @@ namespace Flecs.NET.Codegen
                 string refParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
 
                 str.Append($@"
-                    {GenerateQueryCallbackFunctions($"Iter<{typeParams}>", $"Ecs.IterFieldCallback<{typeParams}>", $"delegate*<Iter, {fieldParams}, void>", "ecs_query_next")}
-                    {GenerateQueryCallbackFunctions($"Iter<{typeParams}>", $"Ecs.IterSpanCallback<{typeParams}>", $"delegate*<Iter, {spanParams}, void>", "ecs_query_next", typeConstraints)}
-                    {GenerateQueryCallbackFunctions($"Iter<{typeParams}>", $"Ecs.IterPointerCallback<{typeParams}>", $"delegate*<Iter, {pointerParams}, void>", "ecs_query_next", typeConstraints)}
-                    {GenerateQueryCallbackFunctions($"Each<{typeParams}>", $"Ecs.EachCallback<{typeParams}>", $"delegate*<{refParams}, void>", "ecs_query_next_instanced")} 
-                    {GenerateQueryCallbackFunctions($"Each<{typeParams}>", $"Ecs.EachEntityCallback<{typeParams}>", $"delegate*<Entity, {refParams}, void>", "ecs_query_next_instanced")} 
-                    {GenerateQueryCallbackFunctions($"Each<{typeParams}>", $"Ecs.EachIndexCallback<{typeParams}>", $"delegate*<Iter, int, {refParams}, void>", "ecs_query_next_instanced")}
-                    {GenerateQueryFindCallbackFunctions(typeParams, $"Ecs.FindCallback<{typeParams}>", $"delegate*<{refParams}, bool>")}
-                    {GenerateQueryFindCallbackFunctions(typeParams, $"Ecs.FindEntityCallback<{typeParams}>", $"delegate*<Entity, {refParams}, bool>")}
-                    {GenerateQueryFindCallbackFunctions(typeParams, $"Ecs.FindIndexCallback<{typeParams}>", $"delegate*<Iter, int, {refParams}, bool>")}
+                    {GenerateIterableCallbackFunctions(false, $"Iter<{typeParams}>", $"Ecs.IterFieldCallback<{typeParams}>", $"delegate*<Iter, {fieldParams}, void>", "GetNext")}
+                    {GenerateIterableCallbackFunctions(false, $"Iter<{typeParams}>", $"Ecs.IterSpanCallback<{typeParams}>", $"delegate*<Iter, {spanParams}, void>", "GetNext", typeConstraints)}
+                    {GenerateIterableCallbackFunctions(false, $"Iter<{typeParams}>", $"Ecs.IterPointerCallback<{typeParams}>", $"delegate*<Iter, {pointerParams}, void>", "GetNext", typeConstraints)}
+                    {GenerateIterableCallbackFunctions(true, $"Each<{typeParams}>", $"Ecs.EachCallback<{typeParams}>", $"delegate*<{refParams}, void>", "GetNextInstanced")} 
+                    {GenerateIterableCallbackFunctions(true, $"Each<{typeParams}>", $"Ecs.EachEntityCallback<{typeParams}>", $"delegate*<Entity, {refParams}, void>", "GetNextInstanced")} 
+                    {GenerateIterableCallbackFunctions(true, $"Each<{typeParams}>", $"Ecs.EachIndexCallback<{typeParams}>", $"delegate*<Iter, int, {refParams}, void>", "GetNextInstanced")}
+                    {GenerateIterableFindCallbackFunctions(typeParams, $"Ecs.FindCallback<{typeParams}>", $"delegate*<{refParams}, bool>")}
+                    {GenerateIterableFindCallbackFunctions(typeParams, $"Ecs.FindEntityCallback<{typeParams}>", $"delegate*<Entity, {refParams}, bool>")}
+                    {GenerateIterableFindCallbackFunctions(typeParams, $"Ecs.FindIndexCallback<{typeParams}>", $"delegate*<Iter, int, {refParams}, bool>")}
                 ");
             }
 
@@ -132,36 +125,7 @@ namespace Flecs.NET.Codegen
                 {{
                     {str}
                 }}
-            ";
-        }
 
-        private static string GenerateIterIterableExtensions()
-        {
-            StringBuilder str = new StringBuilder();
-
-            for (int i = 0; i < GenericCount; i++)
-            {
-                string typeParams = GenerateTypeParams(i + 1);
-                string typeConstraints = ConcatString(i + 1, " ", index => $"where T{index} : unmanaged");
-                string fieldParams = ConcatString(i + 1, ", ", index => $"Field<T{index}>");
-                string spanParams = ConcatString(i + 1, ", ", index => $"Span<T{index}>");
-                string pointerParams = ConcatString(i + 1, ", ", index => $"T{index}*");
-                string refParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
-
-                str.Append($@"
-                    {GenerateIterIterableCallbackFunctions($"Iter<{typeParams}>", $"Ecs.IterFieldCallback<{typeParams}>", $"delegate*<Iter, {fieldParams}, void>", "ecs_query_next")}
-                    {GenerateIterIterableCallbackFunctions($"Iter<{typeParams}>", $"Ecs.IterSpanCallback<{typeParams}>", $"delegate*<Iter, {spanParams}, void>", "ecs_query_next", typeConstraints)}
-                    {GenerateIterIterableCallbackFunctions($"Iter<{typeParams}>", $"Ecs.IterPointerCallback<{typeParams}>", $"delegate*<Iter, {pointerParams}, void>", "ecs_query_next", typeConstraints)}
-                    {GenerateIterIterableCallbackFunctions($"Each<{typeParams}>", $"Ecs.EachCallback<{typeParams}>", $"delegate*<{refParams}, void>", "ecs_query_next_instanced")} 
-                    {GenerateIterIterableCallbackFunctions($"Each<{typeParams}>", $"Ecs.EachEntityCallback<{typeParams}>", $"delegate*<Entity, {refParams}, void>", "ecs_query_next_instanced")} 
-                    {GenerateIterIterableCallbackFunctions($"Each<{typeParams}>", $"Ecs.EachIndexCallback<{typeParams}>", $"delegate*<Iter, int, {refParams}, void>", "ecs_query_next_instanced")}
-                    {GenerateIterIterableFindCallbackFunctions(typeParams, $"Ecs.FindCallback<{typeParams}>", $"delegate*<{refParams}, bool>")}
-                    {GenerateIterIterableFindCallbackFunctions(typeParams, $"Ecs.FindEntityCallback<{typeParams}>", $"delegate*<Entity, {refParams}, bool>")}
-                    {GenerateIterIterableFindCallbackFunctions(typeParams, $"Ecs.FindIndexCallback<{typeParams}>", $"delegate*<Iter, int, {refParams}, bool>")}
-                ");
-            }
-
-            return $@"
                 public unsafe partial struct IterIterable
                 {{
                     {str}
@@ -213,6 +177,36 @@ namespace Flecs.NET.Codegen
                         return Instanced().Build(ref callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
                     }}
 
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, Ecs.IterFieldCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.IterFieldCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, Ecs.IterSpanCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.IterSpanCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, Ecs.IterPointerCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.IterPointerCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, Ecs.EachCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.EachCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, Ecs.EachEntityCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.EachEntityCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, Ecs.EachIndexCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
+                    }}
+
                 #if NET5_0_OR_GREATER
                     public Observer Iter<{typeParams}>(delegate*<Iter, {fieldParams}, void> callback) 
                     {{
@@ -242,6 +236,66 @@ namespace Flecs.NET.Codegen
                     public Observer Each<{typeParams}>(delegate*<Iter, int, {refParams}, void> callback) 
                     {{
                         return Instanced().Build((IntPtr)callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(delegate*<Iter, void> run, Ecs.IterFieldCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.IterFieldCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(delegate*<Iter, void> run, Ecs.IterSpanCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.IterSpanCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(delegate*<Iter, void> run, Ecs.IterPointerCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.IterPointerCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(delegate*<Iter, void> run, Ecs.EachCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.EachCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(delegate*<Iter, void> run, Ecs.EachEntityCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.EachEntityCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(delegate*<Iter, void> run, Ecs.EachIndexCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, {fieldParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.IterFieldCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, {spanParams}, void> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.IterSpanCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, {pointerParams}, void> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.IterPointerCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, delegate*<{refParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.EachCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, delegate*<Entity, {refParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.EachEntityCallbackPointer);
+                    }}
+
+                    public Observer Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, int, {refParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
                     }}
                 #endif
                 ");
@@ -299,6 +353,36 @@ namespace Flecs.NET.Codegen
                         return Instanced().Build(ref callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
                     }}
 
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, Ecs.IterFieldCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.IterFieldCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, Ecs.IterSpanCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.IterSpanCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, Ecs.IterPointerCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.IterPointerCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, Ecs.EachCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.EachCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, Ecs.EachEntityCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.EachEntityCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, Ecs.EachIndexCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun(run).Build(ref callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
+                    }}
+
                 #if NET5_0_OR_GREATER
                     public Routine Iter<{typeParams}>(delegate*<Iter, {fieldParams}, void> callback) 
                     {{
@@ -328,6 +412,66 @@ namespace Flecs.NET.Codegen
                     public Routine Each<{typeParams}>(delegate*<Iter, int, {refParams}, void> callback) 
                     {{
                         return Instanced().Build((IntPtr)callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(delegate*<Iter, void> run, Ecs.IterFieldCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.IterFieldCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(delegate*<Iter, void> run, Ecs.IterSpanCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.IterSpanCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(delegate*<Iter, void> run, Ecs.IterPointerCallback<{typeParams}> callback) {typeConstraints}
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.IterPointerCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(delegate*<Iter, void> run, Ecs.EachCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.EachCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(delegate*<Iter, void> run, Ecs.EachEntityCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.EachEntityCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(delegate*<Iter, void> run, Ecs.EachIndexCallback<{typeParams}> callback)
+                    {{
+                        return PopulateRun((IntPtr)run).Build(ref callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, {fieldParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.IterFieldCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, {spanParams}, void> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.IterSpanCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, {pointerParams}, void> callback) {typeConstraints}
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.IterPointerCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, delegate*<{refParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.EachCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, delegate*<Entity, {refParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.EachEntityCallbackPointer);
+                    }}
+
+                    public Routine Run<{typeParams}>(Ecs.IterCallback run, delegate*<Iter, int, {refParams}, void> callback)
+                    {{
+                        return PopulateRun(run).Build((IntPtr)callback, BindingContext<{typeParams}>.EachIndexCallbackPointer);
                     }}
                 #endif
                 ");
@@ -384,7 +528,7 @@ namespace Flecs.NET.Codegen
             return str.ToString();
         }
 
-        private static string GenerateIterableFactoryExtensions()
+        private static string GenerateBuilderFactoryExtensions()
         {
             StringBuilder str = new StringBuilder();
 
@@ -485,6 +629,7 @@ namespace Flecs.NET.Codegen
             for (int i = 0; i < GenericCount; i++)
             {
                 string typeParams = GenerateTypeParams(i + 1);
+                string refArgs = ConcatString(i + 1, ", ", index => $"ref T{index}");
 
                 str.AppendLine($@"
                     public void Each<{typeParams}>(Ecs.EachCallback<{typeParams}> callback) 
@@ -492,26 +637,26 @@ namespace Flecs.NET.Codegen
                         using Query query = Query<{typeParams}>();
                         query.Each(callback);   
                     }}
-                ");
-            }
 
-            return str.ToString();
-        }
-
-        private static string GenerateWorldEachEntityCallbackFunction()
-        {
-            StringBuilder str = new StringBuilder();
-
-            for (int i = 0; i < GenericCount; i++)
-            {
-                string typeParams = GenerateTypeParams(i + 1);
-
-                str.AppendLine($@"
                     public void Each<{typeParams}>(Ecs.EachEntityCallback<{typeParams}> callback) 
                     {{
                         using Query query = Query<{typeParams}>();
                         query.Each(callback);
                     }}
+
+                #if NET5_0_OR_GREATER
+                    public void Each<{typeParams}>(delegate*<{refArgs}, void> callback) 
+                    {{
+                        using Query query = Query<{typeParams}>();
+                        query.Each(callback);   
+                    }}
+
+                    public void Each<{typeParams}>(delegate*<Entity, {refArgs}, void> callback) 
+                    {{
+                        using Query query = Query<{typeParams}>();
+                        query.Each(callback);
+                    }}
+                #endif
                 ");
             }
 
@@ -692,7 +837,7 @@ namespace Flecs.NET.Codegen
             {
                 string typeParams = GenerateTypeParams(i + 1);
 
-                string functionPointerParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
+                string refArgs = ConcatString(i + 1, ", ", index => $"ref T{index}");
 
                 string fieldAssertions = ConcatString(i + 1, "\n",
                     index => $"Core.Iter.AssertFieldId<T{index}>(iter, {index});");
@@ -709,7 +854,7 @@ namespace Flecs.NET.Codegen
                 string increments = ConcatString(i + 1, ", ",
                     index => $"pointer{index} += size{index}");
 
-                string methodBody = $@"
+                string each = $@"
                     {fieldAssertions}
                     {sizes}
                     {pointers}
@@ -718,7 +863,7 @@ namespace Flecs.NET.Codegen
 
                     Macros.TableLock(iter->world, iter->table);
 
-                    int count = iter->count == 0 ? 1 : iter->count;
+                    int count = iter->count == 0 || iter->table == null ? 1 : iter->count;
 
                     for (int i = 0; i < count; i++, {increments})
                         callback({callbackArgs});
@@ -726,51 +871,8 @@ namespace Flecs.NET.Codegen
                     Macros.TableUnlock(iter->world, iter->table);
                 ";
 
-                str.AppendLine($@"
-                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachCallback<{typeParams}> callback)
-                    {{
-                        {methodBody}
-                    }}
-
-                #if NET5_0_OR_GREATER
-                    public static void Each<{typeParams}>(ecs_iter_t* iter, delegate*<{functionPointerParams}, void> callback)
-                    {{
-                        {methodBody}
-                    }}
-                #endif
-                ");
-            }
-
-            return str.ToString();
-        }
-
-        private static string GenerateEachEntityInvokers()
-        {
-            StringBuilder str = new StringBuilder();
-
-            for (int i = 0; i < GenericCount; i++)
-            {
-                string typeParams = GenerateTypeParams(i + 1);
-
-                string functionPointerParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
-
-                string fieldAssertions = ConcatString(i + 1, "\n",
-                    index => $"Core.Iter.AssertFieldId<T{index}>(iter, {index});");
-
-                string sizes = ConcatString(i + 1, "\n",
-                    index => $"int size{index} = (iter->sources == null || iter->sources[{index}] == 0) && (iter->set_fields & (1 << {index})) != 0 ? Type<T{index}>.Size : 0;");
-
-                string pointers = ConcatString(i + 1, "\n",
-                    index => $"IntPtr pointer{index} = (IntPtr)iter->ptrs[{index}];");
-
-                string callbackArgs = ConcatString(i + 1, ", ",
-                    index => $"ref Managed.GetTypeRef<T{index}>(pointer{index})");
-
-                string increments = ConcatString(i + 1, ", ",
-                    index => $"pointer{index} += size{index}");
-
-                string methodBody = $@"
-                    Ecs.Assert(iter->count > 0, ""No entities returned, use Each() without the entity argument instead."");
+                string eachEntity = $@"
+                    Ecs.Assert(iter->count > 0, ""No entities returned, use Iter() or Each() without the entity argument instead."");
 
                     {fieldAssertions}
                     {sizes}
@@ -780,58 +882,13 @@ namespace Flecs.NET.Codegen
 
                     Macros.TableLock(iter->world, iter->table);
 
-                    int count = iter->count;
-
-                    for (int i = 0; i < count; i++, {increments})
+                    for (int i = 0; i < iter->count; i++, {increments})
                         callback(new Entity(iter->world, iter->entities[i]), {callbackArgs});
 
                     Macros.TableUnlock(iter->world, iter->table);
                 ";
 
-                str.AppendLine($@"
-                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachEntityCallback<{typeParams}> callback)
-                    {{
-                        {methodBody}
-                    }}
-
-                #if NET5_0_OR_GREATER
-                    public static void Each<{typeParams}>(ecs_iter_t* iter, delegate*<Entity, {functionPointerParams}, void> callback)
-                    {{
-                        {methodBody}
-                    }}
-                #endif
-                ");
-            }
-
-            return str.ToString();
-        }
-
-        private static string GenerateEachIndexInvokers()
-        {
-            StringBuilder str = new StringBuilder();
-
-            for (int i = 0; i < GenericCount; i++)
-            {
-                string typeParams = GenerateTypeParams(i + 1);
-
-                string functionPointerParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
-
-                string fieldAssertions = ConcatString(i + 1, "\n",
-                    index => $"Core.Iter.AssertFieldId<T{index}>(iter, {index});");
-
-                string sizes = ConcatString(i + 1, "\n",
-                    index => $"int size{index} = (iter->sources == null || iter->sources[{index}] == 0) && (iter->set_fields & (1 << {index})) != 0 ? Type<T{index}>.Size : 0;");
-
-                string pointers = ConcatString(i + 1, "\n",
-                    index => $"IntPtr pointer{index} = (IntPtr)iter->ptrs[{index}];");
-
-                string callbackArgs = ConcatString(i + 1, ", ",
-                    index => $"ref Managed.GetTypeRef<T{index}>(pointer{index})");
-
-                string increments = ConcatString(i + 1, ", ",
-                    index => $"pointer{index} += size{index}");
-
-                string methodBody = $@"
+                string eachIndex = $@"
                     {fieldAssertions}
                     {sizes}
                     {pointers}
@@ -840,7 +897,7 @@ namespace Flecs.NET.Codegen
 
                     Macros.TableLock(iter->world, iter->table);
 
-                    int count = iter->count == 0 ? 1 : iter->count;
+                    int count = iter->count == 0 || iter->table == null ? 1 : iter->count;
 
                     for (int i = 0; i < count; i++, {increments})
                         callback(new Iter(iter), i, {callbackArgs});
@@ -848,50 +905,18 @@ namespace Flecs.NET.Codegen
                     Macros.TableUnlock(iter->world, iter->table);
                 ";
 
-                str.AppendLine($@"
-                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachIndexCallback<{typeParams}> callback)
-                    {{
-                        {methodBody}
-                    }}
+                string find = $@"
+                    {fieldAssertions}
+                    {sizes}
+                    {pointers}
 
-                #if NET5_0_OR_GREATER
-                    public static void Each<{typeParams}>(ecs_iter_t* iter, delegate*<Iter, int, {functionPointerParams}, void> callback)
-                    {{
-                        {methodBody}
-                    }}
-                #endif
-                ");
-            }
-
-            return str.ToString();
-        }
-
-        private static string GenerateFindInvokers()
-        {
-            StringBuilder str = new StringBuilder();
-
-            for (int i = 0; i < GenericCount; i++)
-            {
-                string typeParams = GenerateTypeParams(i + 1);
-
-                string functionPointerParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
-
-                string typeAssertions = ConcatString(i + 1, "\n",
-                    index => $"Core.Iter.AssertFieldId<T{index}>(iter, {index});");
-
-                string callbackArgs = ConcatString(i + 1, ", ",
-                    index => $"ref Managed.GetTypeRef<T{index}>(iter->ptrs[{index}], i)");
-
-                string methodBody = $@"
                     Macros.TableLock(iter->world, iter->table);
 
-                    int count = iter->count == 0 ? 1 : iter->count;
-                    Iter it = new Iter(iter);
                     Entity result = default;
 
-                    {typeAssertions}
+                    int count = iter->count == 0 || iter->table == null ? 1 : iter->count;
 
-                    for (int i = 0; i < count; i++)
+                    for (int i = 0; i < count; i++, {increments})
                     {{
                         if (!callback({callbackArgs}))
                             continue;
@@ -905,55 +930,23 @@ namespace Flecs.NET.Codegen
                     return result;
                 ";
 
-                str.AppendLine($@"
-                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, Ecs.FindCallback<{typeParams}> callback)
-                    {{
-                        {methodBody}
-                    }}
-                #if NET5_0_OR_GREATER
-                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, delegate*<{functionPointerParams}, bool> callback)
-                    {{
-                        {methodBody}
-                    }}
-                #endif
-                ");
-            }
+                string findEntity = $@"
+                    Ecs.Assert(iter->count > 0, ""No entities returned, use Find() without the Entity argument instead."");
 
-            return str.ToString();
-        }
+                    {fieldAssertions}
+                    {sizes}
+                    {pointers}
 
-        private static string GenerateFindEntityInvokers()
-        {
-            StringBuilder str = new StringBuilder();
-
-            for (int i = 0; i < GenericCount; i++)
-            {
-                string typeParams = GenerateTypeParams(i + 1);
-
-                string functionPointerParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
-
-                string typeAssertions = ConcatString(i + 1, "\n",
-                    index => $"Core.Iter.AssertFieldId<T{index}>(iter, {index});");
-
-                string callbackArgs = ConcatString(i + 1, ", ",
-                    index => $"ref Managed.GetTypeRef<T{index}>(iter->ptrs[{index}], i)");
-
-                string methodBody = $@"
                     Macros.TableLock(iter->world, iter->table);
 
-                    int count = iter->count;
-                    ecs_world_t *world = iter->world;
                     Entity result = default;
 
-                    Ecs.Assert(count > 0, ""No entities returned, use Find() without Entity argument"");
-                    {typeAssertions}
-
-                    for (int i = 0; i < count; i++)
+                    for (int i = 0; i < iter->count; i++, {increments})
                     {{
-                        if (!callback(new Entity(world, iter->entities[i]), {callbackArgs}))
+                        if (!callback(new Entity(iter->world, iter->entities[i]), {callbackArgs}))
                             continue;
 
-                        result = new Entity(world, iter->entities[i]);
+                        result = new Entity(iter->world, iter->entities[i]);
                         break;
                     }}
 
@@ -962,52 +955,20 @@ namespace Flecs.NET.Codegen
                     return result;
                 ";
 
-                str.AppendLine($@"
-                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, Ecs.FindEntityCallback<{typeParams}> callback)
-                    {{
-                        {methodBody}
-                    }}
+                string findIndex = $@"
+                    {fieldAssertions}
+                    {sizes}
+                    {pointers}
 
-                #if NET5_0_OR_GREATER
-                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, delegate*<Entity, {functionPointerParams}, bool> callback)
-                    {{
-                        {methodBody}
-                    }}
-                #endif
-                ");
-            }
-
-            return str.ToString();
-        }
-
-        private static string GenerateFindIndexInvokers()
-        {
-            StringBuilder str = new StringBuilder();
-
-            for (int i = 0; i < GenericCount; i++)
-            {
-                string typeParams = GenerateTypeParams(i + 1);
-
-                string functionPointerParams = ConcatString(i + 1, ", ", index => $"ref T{index}");
-
-                string typeAssertions = ConcatString(i + 1, "\n",
-                    index => $"Core.Iter.AssertFieldId<T{index}>(iter, {index});");
-
-                string callbackArgs = ConcatString(i + 1, ", ",
-                    index => $"ref Managed.GetTypeRef<T{index}>(iter->ptrs[{index}], i)");
-
-                string methodBody = $@"
                     Macros.TableLock(iter->world, iter->table);
 
-                    int count = iter->count == 0 ? 1 : iter->count;
-                    Iter it = new Iter(iter);
                     Entity result = default;
 
-                    {typeAssertions}
+                    int count = iter->count == 0 || iter->table == null ? 1 : iter->count;
 
-                    for (int i = 0; i < count; i++)
+                    for (int i = 0; i < count; i++, {increments})
                     {{
-                        if (!callback(it, i, {callbackArgs}))
+                        if (!callback(new Iter(iter), i, {callbackArgs}))
                             continue;
 
                         result = new Entity(iter->world, iter->entities[i]);
@@ -1020,14 +981,65 @@ namespace Flecs.NET.Codegen
                 ";
 
                 str.AppendLine($@"
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachCallback<{typeParams}> callback)
+                    {{
+                        {each}
+                    }}
+
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachEntityCallback<{typeParams}> callback)
+                    {{
+                        {eachEntity}
+                    }}
+
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, Ecs.EachIndexCallback<{typeParams}> callback)
+                    {{
+                        {eachIndex}
+                    }}
+
+                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, Ecs.FindCallback<{typeParams}> callback)
+                    {{
+                        {find}
+                    }}
+
+                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, Ecs.FindEntityCallback<{typeParams}> callback)
+                    {{
+                        {findEntity}
+                    }}
+
                     public static Entity Find<{typeParams}>(ecs_iter_t* iter, Ecs.FindIndexCallback<{typeParams}> callback)
                     {{
-                        {methodBody}
+                        {findIndex}
                     }}
+
                 #if NET5_0_OR_GREATER
-                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, delegate*<Iter, int, {functionPointerParams}, bool> callback)
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, delegate*<{refArgs}, void> callback)
                     {{
-                        {methodBody}
+                        {each}
+                    }}
+
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, delegate*<Entity, {refArgs}, void> callback)
+                    {{
+                        {eachEntity}
+                    }}
+
+                    public static void Each<{typeParams}>(ecs_iter_t* iter, delegate*<Iter, int, {refArgs}, void> callback)
+                    {{
+                        {eachIndex}
+                    }}
+
+                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, delegate*<{refArgs}, bool> callback)
+                    {{
+                        {find}
+                    }}
+
+                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, delegate*<Entity, {refArgs}, bool> callback)
+                    {{
+                        {findEntity}
+                    }}
+
+                    public static Entity Find<{typeParams}>(ecs_iter_t* iter, delegate*<Iter, int, {refArgs}, bool> callback)
+                    {{
+                        {findIndex}
                     }}
                 #endif
                 ");
@@ -1284,21 +1296,22 @@ namespace Flecs.NET.Codegen
             return $@"
                 internal static void {callbackName}(ecs_iter_t* iter)
                 {{
-                    BindingContext.RunIterContext* context = (BindingContext.RunIterContext*)iter->callback_ctx;
+                    BindingContext.IteratorContext* context = (BindingContext.IteratorContext*)iter->callback_ctx;
             #if NET5_0_OR_GREATER
-                    if (context->Iterator.GcHandle == default)
+                    if (context->Callback.GcHandle == default)
                     {{
-                        Invoker.{invokerName}(iter, ({functionPointerName})context->Iterator.Function);
+                        Invoker.{invokerName}(iter, ({functionPointerName})context->Callback.Function);
                         return;
                     }}
             #endif
-                    {delegateName} callback = ({delegateName})context->Iterator.GcHandle.Target!;
+                    {delegateName} callback = ({delegateName})context->Callback.GcHandle.Target!;
                     Invoker.{invokerName}(iter, callback);
                 }}
             ";
         }
 
-        private static string GenerateQueryCallbackFunctions(
+        private static string GenerateIterableCallbackFunctions(
+            bool instanced,
             string functionName,
             string delegateName,
             string functionPointerName,
@@ -1308,63 +1321,37 @@ namespace Flecs.NET.Codegen
             return $@"
                 public void {functionName}({delegateName} callback) {typeConstraints}
                 {{
-                    {functionName}(World, callback);
-                }}
-
-                public void {functionName}(Entity e, {delegateName} callback) {typeConstraints}
-                {{
-                    {functionName}(e.World, callback);
-                }}
-
-                public void {functionName}(Iter it, {delegateName} callback) {typeConstraints}
-                {{
-                    {functionName}(it.World(), callback);
-                }}
-
-                public void {functionName}(World world, {delegateName} callback) {typeConstraints}
-                {{
-                    ecs_iter_t iter = ecs_query_iter(world, Handle);
-                    while ({nextName}(&iter) == 1)
-                        Invoker.{functionName}(&iter, callback);
+                    ecs_iter_t it = GetIter();
+                    {(instanced ? "it.flags |= EcsIterIsInstanced;" : "")}
+                    while ({nextName}(&it))
+                        Invoker.{functionName}(&it, callback);
                 }}
 
                 #if NET5_0_OR_GREATER
                 public void {functionName}({functionPointerName} callback) {typeConstraints}
                 {{
-                    {functionName}(World, callback);
-                }}
-
-                public void {functionName}(Entity e, {functionPointerName} callback) {typeConstraints}
-                {{
-                    {functionName}(e.World, callback);
-                }}
-
-                public void {functionName}(Iter it, {functionPointerName} callback) {typeConstraints}
-                {{
-                    {functionName}(it.World(), callback);
-                }}
-
-                public void {functionName}(World world, {functionPointerName} callback) {typeConstraints}
-                {{
-                    ecs_iter_t iter = ecs_query_iter(world, Handle);
-                    while ({nextName}(&iter) == 1)
-                        Invoker.{functionName}(&iter, callback);
+                    ecs_iter_t it = GetIter();
+                    {(instanced ? "it.flags |= EcsIterIsInstanced;" : "")}
+                    while ({nextName}(&it))
+                        Invoker.{functionName}(&it, callback);
                 }}
                 #endif
             ";
         }
 
-        private static string GenerateQueryFindCallbackFunctions(string typeParams, string delegateName, string functionPointerName)
+        private static string GenerateIterableFindCallbackFunctions(string typeParams, string delegateName, string functionPointerName)
         {
             string methodBody = $@"
-                ecs_iter_t iter = ecs_query_iter(World, Handle);
+                ecs_iter_t it = GetIter();
+                it.flags |= EcsIterIsInstanced;
+
                 Entity result = default;
 
-                while (result == 0 && ecs_query_next_instanced(&iter) == 1)
-                    result = Invoker.Find(&iter, callback);
+                while (result == 0 && GetNextInstanced(&it))
+                    result = Invoker.Find(&it, callback);
                 
                 if (result != 0)
-                    ecs_iter_fini(&iter);
+                    ecs_iter_fini(&it);
 
                 return result;
             ";
@@ -1380,93 +1367,6 @@ namespace Flecs.NET.Codegen
                     {methodBody}
                 }}
             #endif
-            ";
-        }
-
-        private static string GenerateIterIterableFindCallbackFunctions(string typeParams, string delegateName, string functionPointerName)
-        {
-            string methodBody = $@"
-                ecs_iter_t iter = _iter;
-                Entity result = default;
-
-                while (result == 0 && ecs_query_next_instanced(&iter) == 1)
-                    result = Invoker.Find(&iter, callback);
-                
-                if (result != 0)
-                    ecs_iter_fini(&iter);
-
-                return result;
-            ";
-
-            return $@"
-                public Entity Find<{typeParams}>({delegateName} callback)
-                {{
-                    {methodBody}
-                }}
-            #if NET5_0_OR_GREATER
-                public Entity Find<{typeParams}>({functionPointerName} callback)
-                {{
-                    {methodBody}
-                }}
-            #endif
-            ";
-        }
-
-        private static string GenerateIterIterableCallbackFunctions(
-            string functionName,
-            string delegateName,
-            string functionPointerName,
-            string nextName,
-            string typeConstraints = "")
-        {
-            return $@"
-                public void {functionName}({delegateName} callback) {typeConstraints}
-                {{
-                    {functionName}(_iter.world, callback);
-                }}
-
-                public void {functionName}(Entity e, {delegateName} callback) {typeConstraints}
-                {{
-                    {functionName}(e.World, callback);
-                }}
-
-                public void {functionName}(Iter it, {delegateName} callback) {typeConstraints}
-                {{
-                    {functionName}(it.World(), callback);
-                }}
-
-                public void {functionName}(World world, {delegateName} callback) {typeConstraints}
-                {{
-                    ecs_iter_t iter = _iter;
-                    iter.world = world;
-                    while ({nextName}(&iter) == 1)
-                        Invoker.{functionName}(&iter, callback);
-                }}
-
-                #if NET5_0_OR_GREATER
-                public void {functionName}({functionPointerName} callback) {typeConstraints}
-                {{
-                    {functionName}(_iter.world, callback);
-                }}
-
-                public void {functionName}(Entity e, {functionPointerName} callback) {typeConstraints}
-                {{
-                    {functionName}(e.World, callback);
-                }}
-
-                public void {functionName}(Iter it, {functionPointerName} callback) {typeConstraints}
-                {{
-                    {functionName}(it.World(), callback);
-                }}
-
-                public void {functionName}(World world, {functionPointerName} callback) {typeConstraints}
-                {{
-                    ecs_iter_t iter = _iter;
-                    iter.world = world;
-                    while ({nextName}(&iter) == 1)
-                        Invoker.{functionName}(&iter, callback);
-                }}
-                #endif
             ";
         }
 

--- a/src/Flecs.NET.Examples/Cpp/Queries/Basics.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/Basics.cs
@@ -56,16 +56,21 @@ public static class Cpp_Queries_Basics
             Console.WriteLine($"{it.Entity(i)}: ({p.X}, {p.Y})");
         });
 
-        // Iter is a bit more verbose, but allows for more control over how entities
+        // Run is a bit more verbose, but allows for more control over how entities
         // are iterated as it provides multiple entities in the same callback.
-        q.Iter((Iter it, Field<Position> p, Field<Velocity> v) =>
+        q.Run((Iter it) =>
         {
-
-            foreach (int i in it)
+            while (it.Next())
             {
-                p[i].X += v[i].X;
-                p[i].Y += v[i].Y;
-                Console.WriteLine($"{it.Entity(i)}: ({p[i].X}, {p[i].Y})");
+                Field<Position> p = it.Field<Position>(0);
+                Field<Velocity> v = it.Field<Velocity>(1);
+
+                foreach (int i in it)
+                {
+                    p[i].X += v[i].X;
+                    p[i].Y += v[i].Y;
+                    Console.WriteLine($"{it.Entity(i)}: ({p[i].X}, {p[i].Y})");
+                }
             }
         });
     }

--- a/src/Flecs.NET.Examples/Cpp/Queries/CyclicVariables.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/CyclicVariables.cs
@@ -48,7 +48,7 @@ public static class Cpp_Queries_CyclicVariables
 
         // Because the query doesn't use the This variable we cannot use "each"
         // which iterates the entities array. Instead we can use iter like this:
-        q.Iter((Iter it) =>
+        q.Each((Iter it, int i) =>
         {
             Entity x = it.GetVar(xVar);
             Entity y = it.GetVar(yVar);

--- a/src/Flecs.NET.Examples/Cpp/Queries/GroupBy.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/GroupBy.cs
@@ -81,33 +81,40 @@ public static class Cpp_Queries_GroupBy
         //     - table [Postion, Tag, (Group, Third)]
         //
 
-        q.Iter((Iter it, Field<Position> p) =>
+        q.Run((Iter it) =>
         {
-            Entity group = it.World().Entity(it.GroupId());
+            while (it.Next())
+            {
+                Field<Position> p = it.Field<Position>(0);
 
-            Console.WriteLine($" - Group {group.Path()}: table [{it.Table()}]");
+                Entity group = it.World().Entity(it.GroupId());
 
-            foreach (int i in it)
-                Console.WriteLine($"     ({p[i].X}, {p[i].Y})\n");
+                Console.WriteLine($" - Group {group.Path()}: table [{it.Table()}]");
+
+                foreach (int i in it)
+                    Console.WriteLine($"     ({p[i].X}, {p[i].Y})\n");
+
+                Console.WriteLine();
+            }
         });
     }
 }
 
 // Output:
-//  - Group First: table [Position, (Group,First)]
+//  - Group .First: table [Position, (Group,First)]
 //      (3, 3)
 //
-//  - Group First: table [Position, Tag, (Group,First)]
+//  - Group .First: table [Position, Tag, (Group,First)]
 //      (6, 6)
 //
-//  - Group Second: table [Position, (Group,Second)]
+//  - Group .Second: table [Position, (Group,Second)]
 //      (2, 2)
 //
-//  - Group Second: table [Position, Tag, (Group,Second)]
+//  - Group .Second: table [Position, Tag, (Group,Second)]
 //      (5, 5)
 //
-//  - Group Third: table [Position, (Group,Third)]
+//  - Group .Third: table [Position, (Group,Third)]
 //      (1, 1)
 //
-//  - Group Third: table [Position, Tag, (Group,Third)]
+//  - Group .Third: table [Position, Tag, (Group,Third)]
 //      (4, 4)

--- a/src/Flecs.NET.Examples/Cpp/Queries/GroupByCallbacks.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/GroupByCallbacks.cs
@@ -102,18 +102,23 @@ public static unsafe class Cpp_Queries_GroupByCallbacks
         //     - table [Position, Tag, (Group, Third)]
         //
 
-        q.Iter((Iter it, Field<Position> p) =>
+        q.Run((Iter it) =>
         {
-            Entity group = it.World().Entity(it.GroupId());
-            GroupCtx* ctx = (GroupCtx*)q.GroupCtx(group);
+            while (it.Next())
+            {
+                Field<Position> p = it.Field<Position>(0);
 
-            Console.WriteLine($" - Group {group.Path()}: table [{it.Table().Str()}]");
-            Console.WriteLine($"    Counter: {ctx->Counter}");
+                Entity group = it.World().Entity(it.GroupId());
+                GroupCtx* ctx = (GroupCtx*)q.GroupCtx(group);
 
-            foreach (int i in it)
-                Console.WriteLine($"    ({p[i].X}, {p[i].Y})");
+                Console.WriteLine($" - Group {group.Path()}: table [{it.Table().Str()}]");
+                Console.WriteLine($"    Counter: {ctx->Counter}");
 
-            Console.WriteLine();
+                foreach (int i in it)
+                    Console.WriteLine($"    ({p[i].X}, {p[i].Y})");
+
+                Console.WriteLine();
+            }
         });
 
         // Deleting the query will call the OnGroupDeleted callback
@@ -126,27 +131,27 @@ public static unsafe class Cpp_Queries_GroupByCallbacks
 // Group Second created
 // Group First created
 //
-//  - Group First: table [Position, (Group,First)]
+//  - Group .First: table [Position, (Group,First)]
 //     Counter: 3
 //     (3, 3)
 //
-//  - Group First: table [Position, Tag, (Group,First)]
+//  - Group .First: table [Position, Tag, (Group,First)]
 //     Counter: 3
 //     (6, 6)
 //
-//  - Group Second: table [Position, (Group,Second)]
+//  - Group .Second: table [Position, (Group,Second)]
 //     Counter: 2
 //     (2, 2)
 //
-//  - Group Second: table [Position, Tag, (Group,Second)]
+//  - Group .Second: table [Position, Tag, (Group,Second)]
 //     Counter: 2
 //     (5, 5)
 //
-//  - Group Third: table [Position, (Group,Third)]
+//  - Group .Third: table [Position, (Group,Third)]
 //     Counter: 1
 //     (1, 1)
 //
-//  - Group Third: table [Position, Tag, (Group,Third)]
+//  - Group .Third: table [Position, Tag, (Group,Third)]
 //     Counter: 1
 //     (4, 4)
 //

--- a/src/Flecs.NET.Examples/Cpp/Queries/GroupByCustom.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/GroupByCustom.cs
@@ -67,15 +67,20 @@ public static class Cpp_Queries_GroupByCustom
         //     - table [Postion, Tag, (Group, Third)]
         //
 
-        q.Iter((Iter it, Field<Position> p) =>
+        q.Run((Iter it) =>
         {
-            Entity group = world.Entity(it.GroupId());
-            Console.WriteLine($" - Group {group.Path()}: Table [{it.Table()}]");
+            while (it.Next())
+            {
+                Field<Position> p = it.Field<Position>(0);
 
-            foreach (int i in it)
-                Console.WriteLine($"     ({p[i].X}, {p[i].Y})");
+                Entity group = world.Entity(it.GroupId());
+                Console.WriteLine($" - Group {group.Path()}: Table [{it.Table()}]");
 
-            Console.WriteLine();
+                foreach (int i in it)
+                    Console.WriteLine($"     ({p[i].X}, {p[i].Y})");
+
+                Console.WriteLine();
+            }
         });
     }
 
@@ -89,20 +94,20 @@ public static class Cpp_Queries_GroupByCustom
 }
 
 // Output:
-//  - Group First: Table [Position, (Group,First)]
+//  - Group .First: Table [Position, (Group,First)]
 //      (3, 3)
 //
-//  - Group First: Table [Position, Tag, (Group,First)]
+//  - Group .First: Table [Position, Tag, (Group,First)]
 //      (6, 6)
 //
-//  - Group Second: Table [Position, (Group,Second)]
+//  - Group .Second: Table [Position, (Group,Second)]
 //      (2, 2)
 //
-//  - Group Second: Table [Position, Tag, (Group,Second)]
+//  - Group .Second: Table [Position, Tag, (Group,Second)]
 //      (5, 5)
 //
-//  - Group Third: Table [Position, (Group,Third)]
+//  - Group .Third: Table [Position, (Group,Third)]
 //      (1, 1)
 //
-//  - Group Third: Table [Position, Tag, (Group,Third)]
+//  - Group .Third: Table [Position, Tag, (Group,Third)]
 //      (4, 4)

--- a/src/Flecs.NET.Examples/Cpp/Queries/GroupIter.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/GroupIter.cs
@@ -69,20 +69,26 @@ public static class Cpp_Queries_GroupIter
 
         // Iterate all tables
         Console.WriteLine("All tables:");
-        q.Iter((Iter it) =>
+        q.Run((Iter it) =>
         {
-            Entity group = it.World().Entity(it.GroupId());
-            Console.WriteLine($" - Group {group.Path()}: Table [{it.Table()}]");
+            while (it.Next())
+            {
+                Entity group = it.World().Entity(it.GroupId());
+                Console.WriteLine($" - Group {group.Path()}: Table [{it.Table()}]");
+            }
         });
 
         Console.WriteLine();
 
         // Only iterate entities in cell 10
         Console.WriteLine("Tables for cell 1_0:");
-        q.SetGroup<Cell10>().Iter((Iter it) =>
+        q.SetGroup<Cell10>().Run((Iter it) =>
         {
-            Entity group = it.World().Entity(it.GroupId());
-            Console.WriteLine($" - Group {group.Path()}: Table [{it.Table()}]");
+            while (it.Next())
+            {
+                Entity group = it.World().Entity(it.GroupId());
+                Console.WriteLine($" - Group {group.Path()}: Table [{it.Table()}]");
+            }
         });
     }
 }

--- a/src/Flecs.NET.Examples/Cpp/Queries/Hierarchy.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/Hierarchy.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Flecs.NET.Core;
 
 // Components
@@ -48,19 +49,15 @@ public static class Cpp_Queries_Hierarchy
                 .Optional() // Make term component optional so we also match the root (sun)
             .Build();
 
-        // Do the transform
-        q.Iter((Iter it, Field<Position> selfLocal, Field<Position> selfGlobal, Field<Position> parentGlobal) =>
+        q.Each((ref Position selfLocal, ref Position selfGlobal, ref Position parentGlobal) =>
         {
-            foreach (int i in it)
-            {
-                selfGlobal[i].X = selfLocal[i].X;
-                selfGlobal[i].Y = selfLocal[i].Y;
+            selfGlobal.X = selfLocal.X;
+            selfGlobal.Y = selfLocal.Y;
 
-                if (!parentGlobal.IsNull)
-                {
-                    selfGlobal[i].X += parentGlobal[i].X;
-                    selfGlobal[i].Y += parentGlobal[i].Y;
-                }
+            if (!Unsafe.IsNullRef(ref parentGlobal))
+            {
+                selfGlobal.X += parentGlobal.X;
+                selfGlobal.Y += parentGlobal.Y;
             }
         });
 

--- a/src/Flecs.NET.Examples/Cpp/Queries/Instancing.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/Instancing.cs
@@ -38,7 +38,7 @@ public static class Cpp_Queries_Instancing
         // Create a query for Position, Velocity. We'll create a few entities that
         // have Velocity as owned and shared component.
         Query q = world.QueryBuilder<Position, Velocity>()
-            .TermAt(1).Self() // Position must always be owned by the entity
+            .TermAt(0).Self() // Position must always be owned by the entity
             .Instanced()      // Create instanced query
             .Build();
 
@@ -67,31 +67,37 @@ public static class Cpp_Queries_Instancing
         // to check whether a field is owned or not in order to know how to access
         // it. In the case of an owned field it is iterated as an array, whereas
         // in the case of a shared field, it is accessed as a pointer.
-        q.Iter((Iter it, Field<Position> p , Field<Velocity> v) =>
+        q.Run((Iter it) =>
         {
-            // Check if Velocity is owned, in which case it's accessed as array.
-            // Position will always be owned, since we set the term to Self.
-            if (it.IsSelf(2)) // Velocity is term 2
+            while (it.Next())
             {
-                Console.WriteLine("Velocity is owned");
+                Field<Position> p = it.Field<Position>(0);
+                Field<Velocity> v = it.Field<Velocity>(1);
 
-                foreach (int i in it)
+                // Check if Velocity is owned, in which case it's accessed as array.
+                // Position will always be owned, since we set the term to Self.
+                if (it.IsSelf(1)) // Velocity is term 2
                 {
-                    p[i].X += v[i].X;
-                    p[i].Y += v[i].Y;
-                    Console.WriteLine($"{it.Entity(i)}: ({p[i].X}, {p[i].Y})");
+                    Console.WriteLine("Velocity is owned");
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[i].X;
+                        p[i].Y += v[i].Y;
+                        Console.WriteLine($"{it.Entity(i)}: ({p[i].X}, {p[i].Y})");
+                    }
                 }
-            }
-            // If Velocity is shared, access the field from the index 0.
-            else
-            {
-                Console.WriteLine("Velocity is shared");
-
-                foreach (int i in it)
+                // If Velocity is shared, access the field from the index 0.
+                else
                 {
-                    p[i].X += v[0].X;
-                    p[i].Y += v[0].Y;
-                    Console.WriteLine($"{it.Entity(i)}: ({p[i].X}, {p[i].Y})");
+                    Console.WriteLine("Velocity is shared");
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[0].X;
+                        p[i].Y += v[0].Y;
+                        Console.WriteLine($"{it.Entity(i)}: ({p[i].X}, {p[i].Y})");
+                    }
                 }
             }
         });

--- a/src/Flecs.NET.Examples/Cpp/Queries/Iter.cs
+++ b/src/Flecs.NET.Examples/Cpp/Queries/Iter.cs
@@ -28,35 +28,41 @@ public static class Cpp_Queries_Iter
             .Set<Velocity>(new(4, 5))
             .Set<Mass>(new(50));
 
-        // The iter function provides a Iter object which contains all sorts
+        // The run function provides a Iter object which contains all sorts
         // of information on the entities currently being iterated.
         // The function passed to iter is by default called for each table the query
         // is matched with.
-        q.Iter((Iter it, Field<Position> p, Field<Velocity> v) =>
+        q.Run((Iter it) =>
         {
-            // Print the table & number of entities matched in current callback
-            Console.WriteLine($"Table [{it.Type()}]");
-            Console.WriteLine($" - Number of entities: {it.Count()}");
-
-            // Print information about the components being matched
-            for (int i = 1; i <= it.FieldCount(); i++)
+            while (it.Next())
             {
-                Console.WriteLine($" - Term {i}:");
-                Console.WriteLine($"   - Component: {it.Id(i)}");
-                Console.WriteLine($"   - Type size: {it.Size(i)}");
+                Field<Position> p = it.Field<Position>(0);
+                Field<Velocity> v = it.Field<Velocity>(1);
+
+                // Print the table & number of entities matched in current callback
+                Console.WriteLine($"Table [{it.Type()}]");
+                Console.WriteLine($" - Number of entities: {it.Count()}");
+
+                // Print information about the components being matched
+                for (int i = 0; i < it.FieldCount(); i++)
+                {
+                    Console.WriteLine($" - Term {i}:");
+                    Console.WriteLine($"   - Component: {it.Id(i)}");
+                    Console.WriteLine($"   - Type size: {it.Size(i)}");
+                }
+
+                Console.WriteLine();
+
+                // Iterate entities
+                foreach (int i in it)
+                {
+                    p[i].X += v[i].X;
+                    p[i].Y += v[i].Y;
+                    Console.WriteLine($" - {it.Entity(i)}: ({p[i].X}, {p[i].Y})");
+                }
+
+                Console.WriteLine();
             }
-
-            Console.WriteLine();
-
-            // Iterate entities
-            foreach (int i in it)
-            {
-                p[i].X += v[i].X;
-                p[i].Y += v[i].Y;
-                Console.WriteLine($" - {it.Entity(i)}: ({p[i].X}, {p[i].Y})");
-            }
-
-            Console.WriteLine();
         });
     }
 }

--- a/src/Flecs.NET.Examples/Cpp/Relationships/Union.cs
+++ b/src/Flecs.NET.Examples/Cpp/Relationships/Union.cs
@@ -36,9 +36,8 @@ public static class Cpp_Relationships_Union
     {
         using World world = World.Create();
 
-        // TODO: RIP unions
-        // world.Component<Movement>().Entity.Add(Ecs.Union);
-        // world.Component<Direction>().Entity.Add(Ecs.Union);
+        world.Component<Movement>().Entity.Add(Ecs.Union);
+        world.Component<Direction>().Entity.Add(Ecs.Union);
 
         // Create a query that subscribes for all entities that have a Direction
         // and that are walking
@@ -64,23 +63,15 @@ public static class Cpp_Relationships_Union
         e3.Add(Movement.Walking);
 
         // Iterate the query
-        q.Iter((Iter it) =>
+        q.Each((Iter it, int i) =>
         {
-            // Get the column with direction states. This is stored as an array
-            // with identifiers to the individual states
-            Field<ulong> movement = it.Field<ulong>(0);
-            Field<ulong> direction = it.Field<ulong>(1);
-
-            foreach (int i in it)
-            {
-                // Movement will always be Walking, Direction can be any state
-                Console.Write(it.Entity(i).Name());
-                Console.Write(": Movement: ");
-                Console.Write(it.World().GetAlive(movement[i]).Name());
-                Console.Write(", Direction: ");
-                Console.Write(it.World().GetAlive(direction[i]).Name());
-                Console.WriteLine();
-            }
+            // Movement will always be Walking, Direction can be any state
+            Console.Write(it.Entity(i).Name());
+            Console.Write(": Movement: ");
+            Console.Write(it.Pair(0).Second().Name());
+            Console.Write(", Direction: ");
+            Console.Write(it.Pair(1).Second().Name());
+            Console.WriteLine();
         });
     }
 }

--- a/src/Flecs.NET.Examples/Cpp/Systems/CustomPhases.cs
+++ b/src/Flecs.NET.Examples/Cpp/Systems/CustomPhases.cs
@@ -24,15 +24,15 @@ public static class Cpp_Systems_CustomPhases
         // Create 3 dummy systems.
         world.Routine("CollisionSystem")
             .Kind(collisions)
-            .Iter(Sys);
+            .Run(Sys);
 
         world.Routine("PhysicsSystem")
             .Kind(physics)
-            .Iter(Sys);
+            .Run(Sys);
 
         world.Routine("GameSystem")
             .Kind(Ecs.OnUpdate)
-            .Iter(Sys);
+            .Run(Sys);
 
         // Run pipeline
         world.Progress();

--- a/src/Flecs.NET.Examples/Cpp/Systems/CustomPhasesNoBuiltIn.cs
+++ b/src/Flecs.NET.Examples/Cpp/Systems/CustomPhasesNoBuiltIn.cs
@@ -27,15 +27,15 @@ public static class Cpp_Systems_CustomPhasesNoBuiltIn
         // Create 3 dummy systems.
         world.Routine("CollisionSystem")
             .Kind(collisions)
-            .Iter(Sys);
+            .Run(Sys);
 
         world.Routine("PhysicsSystem")
             .Kind(collisions)
-            .Iter(Sys);
+            .Run(Sys);
 
         world.Routine("GameSystem")
             .Kind(update)
-            .Iter(Sys);
+            .Run(Sys);
 
         // Run pipeline
         world.Progress();

--- a/src/Flecs.NET.Examples/Cpp/Systems/CustomPipeline.cs
+++ b/src/Flecs.NET.Examples/Cpp/Systems/CustomPipeline.cs
@@ -31,7 +31,7 @@ public static class Cpp_Systems_CustomPipeline
         // Create system with Physics tag
         world.Routine()
             .Kind<Physics>()
-            .Iter(() =>
+            .Run((Iter it) =>
             {
                 Console.WriteLine("System ran!");
             });

--- a/src/Flecs.NET.Examples/Cpp/Systems/DeltaTime.cs
+++ b/src/Flecs.NET.Examples/Cpp/Systems/DeltaTime.cs
@@ -10,7 +10,7 @@ public static class Cpp_Systems_DeltaTime
         // components which means it won't match any entities, but will still be ran
         // once for each call to ecs_progress.
         world.Routine()
-            .Iter((Iter it) =>
+            .Run((Iter it) =>
             {
                 Console.WriteLine($"Delta time: {it.DeltaTime()}");
             });

--- a/src/Flecs.NET.Examples/Cpp/Systems/StartupSystem.cs
+++ b/src/Flecs.NET.Examples/Cpp/Systems/StartupSystem.cs
@@ -18,14 +18,14 @@ public static class Cpp_Systems_StartupSystem
         // Startup system
         world.Routine("Startup")
             .Kind(Ecs.OnStart)
-            .Iter((Iter it) =>
+            .Run((Iter it) =>
             {
                 Console.WriteLine(it.System().ToString());
             });
 
         // Regular system
         world.Routine("Update")
-            .Iter((Iter it) =>
+            .Run((Iter it) =>
             {
                 Console.WriteLine(it.System().ToString());
             });

--- a/src/Flecs.NET.Examples/Cpp/Systems/TargetFps.cs
+++ b/src/Flecs.NET.Examples/Cpp/Systems/TargetFps.cs
@@ -10,7 +10,7 @@ public static class Cpp_Systems_TargetFps
         // components which means it won't match any entities, but will still be ran
         // once for each call to ecs_progress.
         world.Routine()
-            .Iter((Iter it) =>
+            .Run((Iter it) =>
             {
                 Console.WriteLine($"Delta time: {it.DeltaTime()}");
             });

--- a/src/Flecs.NET.Examples/Cpp/Systems/TimeInterval.cs
+++ b/src/Flecs.NET.Examples/Cpp/Systems/TimeInterval.cs
@@ -10,11 +10,11 @@ public static class Cpp_Systems_TimeInterval
 
         world.Routine("Tick")
             .Interval(1.0f)
-            .Iter(Tick);
+            .Run(Tick);
 
         world.Routine("FastTick")
             .Interval(0.5f)
-            .Iter(Tick);
+            .Run(Tick);
 
         // Run the main loop at 60 FPS
         world.SetTargetFps(60);

--- a/src/Flecs.NET.Tests/Cpp/EventTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/EventTests.cs
@@ -246,11 +246,14 @@ namespace Flecs.NET.Tests.Cpp
             world.Observer()
                 .Event(evt)
                 .With(id)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.True(it.Entity(0) == e1);
-                    Assert.Equal(10, it.Param<EvtData>().Value);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.True(it.Entity(0) == e1);
+                        Assert.Equal(10, it.Param<EvtData>().Value);
+                        count++;
+                    }
                 });
 
             EvtData data = new EvtData { Value = 10 };
@@ -277,11 +280,14 @@ namespace Flecs.NET.Tests.Cpp
             world.Observer()
                 .Event<EvtData>()
                 .With(id)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.True(it.Entity(0) == e1);
-                    Assert.Equal(10, it.Param<EvtData>().Value);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.True(it.Entity(0) == e1);
+                        Assert.Equal(10, it.Param<EvtData>().Value);
+                        count++;
+                    }
                 });
 
             EvtData evtData = new EvtData { Value = 10 };

--- a/src/Flecs.NET.Tests/Cpp/PairTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/PairTests.cs
@@ -168,15 +168,18 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .Expr("(Pair, *)")
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Field<Pair> tr = it.Field<Pair>(0);
-                    invokeCount++;
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        entityCount++;
-                        traitValue += (int)tr[i].Value;
+                        Field<Pair> tr = it.Field<Pair>(0);
+                        invokeCount++;
+
+                        foreach (int i in it)
+                        {
+                            entityCount++;
+                            traitValue += (int)tr[i].Value;
+                        }
                     }
                 });
 
@@ -202,15 +205,18 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .Expr("(Pair, *)")
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Field<Pair> tr = it.Field<Pair>(0);
-                    invokeCount++;
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        entityCount++;
-                        traitValue += (int)tr[i].Value;
+                        Field<Pair> tr = it.Field<Pair>(0);
+                        invokeCount++;
+
+                        foreach (int i in it)
+                        {
+                            entityCount++;
+                            traitValue += (int)tr[i].Value;
+                        }
                     }
                 });
 

--- a/src/Flecs.NET.Tests/Cpp/QueryBuilderTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/QueryBuilderTests.cs
@@ -803,13 +803,16 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q1.Iter((Iter it) =>
+            q1.Run((Iter it) =>
             {
-                q2.SetVar("this", it.Table()).Each((Entity e) =>
+                while (it.Next())
                 {
-                    Assert.True(e == e3);
-                    count++;
-                });
+                    q2.SetVar("this", it.Table()).Each((Entity e) =>
+                    {
+                        Assert.True(e == e3);
+                        count++;
+                    });
+                }
             });
 
             Assert.Equal(1, count);
@@ -839,13 +842,16 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q1.Iter((Iter it) =>
+            q1.Run((Iter it) =>
             {
-                q2.SetVar("this", it.Range()).Each((Entity e) =>
+                while (it.Next())
                 {
-                    Assert.True(e == e3);
-                    count++;
-                });
+                    q2.SetVar("this", it.Range()).Each((Entity e) =>
+                    {
+                        Assert.True(e == e3);
+                        count++;
+                    });
+                }
             });
 
             Assert.Equal(1, count);
@@ -1130,19 +1136,23 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Iter((Iter it, Field<Self> s) =>
+            q.Run((Iter it) =>
             {
-                Field<Other> o = it.Field<Other>(1);
-                Assert.True(!it.IsSelf(1));
-                Assert.Equal(10, o[0].Value);
-
-                ref Other oRef = ref o[0];
-                Assert.Equal(10, oRef.Value);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Other> o = it.Field<Other>(1);
+                    Assert.True(!it.IsSelf(1));
+                    Assert.Equal(10, o[0].Value);
+
+                    ref Other oRef = ref o[0];
+                    Assert.Equal(10, oRef.Value);
+
+                    foreach (int i in it)
+                    {
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -1171,16 +1181,20 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Iter((Iter it, Field<Self> s) =>
+            q.Run((Iter it) =>
             {
-                Field<Other> o = it.Field<Other>(1);
-                Assert.True(!it.IsSelf(1));
-                Assert.Equal(10, o[0].Value);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Other> o = it.Field<Other>(1);
+                    Assert.True(!it.IsSelf(1));
+                    Assert.Equal(10, o[0].Value);
+
+                    foreach (int i in it)
+                    {
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -1214,23 +1228,27 @@ namespace Flecs.NET.Tests.Cpp
             int count = 0;
             int ownedCount = 0;
 
-            q.Iter((Iter it, Field<Self> s) =>
+            q.Run((Iter it) =>
             {
-                Field<Other> o = it.Field<Other>(1);
+                while (it.Next())
+                {
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Other> o = it.Field<Other>(1);
 
-                if (!it.IsSelf(1))
-                    Assert.Equal(10, o[0].Value);
-                else
+                    if (!it.IsSelf(1))
+                        Assert.Equal(10, o[0].Value);
+                    else
+                        foreach (int i in it)
+                        {
+                            Assert.Equal(20, o[i].Value);
+                            ownedCount++;
+                        }
+
                     foreach (int i in it)
                     {
-                        Assert.Equal(20, o[i].Value);
-                        ownedCount++;
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
                     }
-
-                foreach (int i in it)
-                {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
                 }
             });
 
@@ -1260,16 +1278,20 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Iter((Iter it, Field<Self> s) =>
+            q.Run((Iter it) =>
             {
-                Field<Other> o = it.Field<Other>(1);
-                Assert.True(!it.IsSelf(1));
-                Assert.Equal(10, o[0].Value);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Other> o = it.Field<Other>(1);
+                    Assert.True(!it.IsSelf(1));
+                    Assert.Equal(10, o[0].Value);
+
+                    foreach (int i in it)
+                    {
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -1303,23 +1325,27 @@ namespace Flecs.NET.Tests.Cpp
             int count = 0;
             int ownedCount = 0;
 
-            q.Iter((Iter it, Field<Self> s) =>
+            q.Run((Iter it) =>
             {
-                Field<Other> o = it.Field<Other>(1);
+                while (it.Next())
+                {
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Other> o = it.Field<Other>(1);
 
-                if (!it.IsSelf(1))
-                    Assert.Equal(10, o[0].Value);
-                else
+                    if (!it.IsSelf(1))
+                        Assert.Equal(10, o[0].Value);
+                    else
+                        foreach (int i in it)
+                        {
+                            Assert.Equal(20, o[i].Value);
+                            ownedCount++;
+                        }
+
                     foreach (int i in it)
                     {
-                        Assert.Equal(20, o[i].Value);
-                        ownedCount++;
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
                     }
-
-                foreach (int i in it)
-                {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
                 }
             });
 
@@ -2037,7 +2063,11 @@ namespace Flecs.NET.Tests.Cpp
             Routine s = world.Routine<RelData, Velocity>()
                 .TermAt(0).Second(Ecs.Wildcard)
                 .TermAt(1).Singleton()
-                .Iter((Iter it) => { count += it.Count(); });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        count += it.Count();
+                });
 
             world.Entity().Add<RelData, Tag>();
             world.Set(new Velocity());
@@ -2064,22 +2094,25 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-
-                count += it.Count();
-
-                if (it.Entity(0) == e1)
+                while (it.Next())
                 {
-                    Assert.True(it.IsSet(0));
-                    Assert.True(it.IsSet(1));
-                }
-                else
-                {
-                    Assert.True(it.Entity(0) == e2);
-                    Assert.True(it.IsSet(0));
-                    Assert.False(it.IsSet(1));
+                    Assert.Equal(1, it.Count());
+
+                    count += it.Count();
+
+                    if (it.Entity(0) == e1)
+                    {
+                        Assert.True(it.IsSet(0));
+                        Assert.True(it.IsSet(1));
+                    }
+                    else
+                    {
+                        Assert.True(it.Entity(0) == e2);
+                        Assert.True(it.IsSet(0));
+                        Assert.False(it.IsSet(1));
+                    }
                 }
             });
 
@@ -2121,12 +2154,15 @@ namespace Flecs.NET.Tests.Cpp
                 .Add<TagJ>();
 
             int count = 0;
-            f.Iter((Iter it) =>
+            f.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                Assert.True(it.Entity(0) == e);
-                Assert.Equal(10, it.FieldCount());
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    Assert.True(it.Entity(0) == e);
+                    Assert.Equal(10, it.FieldCount());
+                    count++;
+                }
             });
 
             Assert.Equal(1, count);
@@ -2183,12 +2219,15 @@ namespace Flecs.NET.Tests.Cpp
                 .Add<TagT>();
 
             int count = 0;
-            f.Iter((Iter it) =>
+            f.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                Assert.True(it.Entity(0) == e);
-                Assert.Equal(16, it.FieldCount());
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    Assert.True(it.Entity(0) == e);
+                    Assert.Equal(16, it.FieldCount());
+                    count++;
+                }
             });
 
             Assert.Equal(1, count);
@@ -2232,34 +2271,40 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                if (count == 0)
-                    Assert.True(it.Entity(0) == e1);
-                else if (count == 1)
-                    Assert.True(it.Entity(0) == e2);
-                else if (count == 2)
-                    Assert.True(it.Entity(0) == e3);
-                else
-                    Assert.True(false);
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    if (count == 0)
+                        Assert.True(it.Entity(0) == e1);
+                    else if (count == 1)
+                        Assert.True(it.Entity(0) == e2);
+                    else if (count == 2)
+                        Assert.True(it.Entity(0) == e3);
+                    else
+                        Assert.True(false);
+                    count++;
+                }
             });
             Assert.Equal(3, count);
 
             count = 0;
-            qReverse.Iter((Iter it) =>
+            qReverse.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                if (count == 0)
-                    Assert.True(it.Entity(0) == e3);
-                else if (count == 1)
-                    Assert.True(it.Entity(0) == e2);
-                else if (count == 2)
-                    Assert.True(it.Entity(0) == e1);
-                else
-                    Assert.True(false);
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    if (count == 0)
+                        Assert.True(it.Entity(0) == e3);
+                    else if (count == 1)
+                        Assert.True(it.Entity(0) == e2);
+                    else if (count == 2)
+                        Assert.True(it.Entity(0) == e1);
+                    else
+                        Assert.True(false);
+                    count++;
+                }
             });
             Assert.Equal(3, count);
         }
@@ -2291,34 +2336,40 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                if (count == 0)
-                    Assert.True(it.Entity(0) == e1);
-                else if (count == 1)
-                    Assert.True(it.Entity(0) == e2);
-                else if (count == 2)
-                    Assert.True(it.Entity(0) == e3);
-                else
-                    Assert.True(false);
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    if (count == 0)
+                        Assert.True(it.Entity(0) == e1);
+                    else if (count == 1)
+                        Assert.True(it.Entity(0) == e2);
+                    else if (count == 2)
+                        Assert.True(it.Entity(0) == e3);
+                    else
+                        Assert.True(false);
+                    count++;
+                }
             });
             Assert.Equal(3, count);
 
             count = 0;
-            qReverse.Iter((Iter it) =>
+            qReverse.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                if (count == 0)
-                    Assert.True(it.Entity(0) == e3);
-                else if (count == 1)
-                    Assert.True(it.Entity(0) == e2);
-                else if (count == 2)
-                    Assert.True(it.Entity(0) == e1);
-                else
-                    Assert.True(false);
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    if (count == 0)
+                        Assert.True(it.Entity(0) == e3);
+                    else if (count == 1)
+                        Assert.True(it.Entity(0) == e2);
+                    else if (count == 2)
+                        Assert.True(it.Entity(0) == e1);
+                    else
+                        Assert.True(false);
+                    count++;
+                }
             });
             Assert.Equal(3, count);
         }
@@ -3056,16 +3107,20 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Iter((Iter it, Field<Self> s) =>
+            q.Run((Iter it) =>
             {
-                Field<Other> o = it.Field<Other>(1);
-                Assert.True(!it.IsSelf(1));
-                Assert.Equal(10, o[0].Value);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Other> o = it.Field<Other>(1);
+                    Assert.True(!it.IsSelf(1));
+                    Assert.Equal(10, o[0].Value);
+
+                    foreach (int i in it)
+                    {
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -3215,7 +3270,7 @@ namespace Flecs.NET.Tests.Cpp
             Query q = world.Query<Position>();
 
             int count = 0;
-            q.Each(stage, (Iter it, int i) =>
+            q.Iter(stage).Each((Iter it, int i) =>
             {
                 Assert.True(it.World() == stage);
                 Assert.True(it.Entity(i) == e1);
@@ -3551,12 +3606,16 @@ namespace Flecs.NET.Tests.Cpp
                 .Build();
 
             int count = 0;
-            f.Iter((Iter it, Field<Position> p) =>
+            f.Run((Iter it) =>
             {
-                count++;
-                Assert.Equal(10, p[0].X);
-                Assert.Equal(20, p[0].Y);
-                Assert.True(it.Src(0) == e);
+                while (it.Next())
+                {
+                    Field<Position> p = it.Field<Position>(0);
+                    count++;
+                    Assert.Equal(10, p[0].X);
+                    Assert.Equal(20, p[0].Y);
+                    Assert.True(it.Src(0) == e);
+                }
             });
 
             Assert.Equal(1, count);
@@ -3576,7 +3635,7 @@ namespace Flecs.NET.Tests.Cpp
         //         .Build();
         //
         //     int count = 0;
-        //     f.Iter((Iter it) =>
+        //     f.Run((Iter it) =>
         //     {
         //         Field<Position> p = it.Field<Position>(0);
         //         Assert.True(it.IsReadonly(0));
@@ -3605,7 +3664,7 @@ namespace Flecs.NET.Tests.Cpp
         //         .Build();
         //
         //     int count = 0, setCount = 0;
-        //     f.Iter((Iter it) =>
+        //     f.Run((Iter it) =>
         //     {
         //         Assert.Equal(1, it.Count());
         //         if (it.IsSet(1))
@@ -3786,15 +3845,18 @@ namespace Flecs.NET.Tests.Cpp
             Entity e2 = world.Entity().Set(new Position(20, 30));
 
             int count = 0;
-            f.Iter((Iter it) =>
+            f.Run((Iter it) =>
             {
-                Field<Position> p = it.Field<Position>(0);
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += 1;
-                    p[i].Y += 2;
+                    Field<Position> p = it.Field<Position>(0);
+                    foreach (int i in it)
+                    {
+                        p[i].X += 1;
+                        p[i].Y += 2;
 
-                    count++;
+                        count++;
+                    }
                 }
             });
 
@@ -3824,14 +3886,17 @@ namespace Flecs.NET.Tests.Cpp
             world.Entity().IsA(@base);
 
             int count = 0;
-            f.Iter((Iter it) =>
+            f.Run((Iter it) =>
             {
-                Field<Position> p = it.Field<Position>(0);
-                for (int i = 0; i < it.Count(); i++)
+                while (it.Next())
                 {
-                    Assert.Equal(10, p[0].X);
-                    Assert.Equal(20, p[0].Y);
-                    count++;
+                    Field<Position> p = it.Field<Position>(0);
+                    for (int i = 0; i < it.Count(); i++)
+                    {
+                        Assert.Equal(10, p[0].X);
+                        Assert.Equal(20, p[0].Y);
+                        count++;
+                    }
                 }
             });
 
@@ -3853,15 +3918,18 @@ namespace Flecs.NET.Tests.Cpp
             world.Entity().IsA(@base);
 
             int count = 0;
-            f.Iter((Iter it) =>
+            f.Run((Iter it) =>
             {
-                Field<Position> p = it.Field<Position>(0);
-                Position pv = p[0];
-                for (int i = 0; i < it.Count(); i++)
+                while (it.Next())
                 {
-                    Assert.Equal(10, pv.X);
-                    Assert.Equal(20, pv.Y);
-                    count++;
+                    Field<Position> p = it.Field<Position>(0);
+                    Position pv = p[0];
+                    for (int i = 0; i < it.Count(); i++)
+                    {
+                        Assert.Equal(10, pv.X);
+                        Assert.Equal(20, pv.Y);
+                        count++;
+                    }
                 }
             });
 
@@ -5066,10 +5134,13 @@ namespace Flecs.NET.Tests.Cpp
             Entity e = world.Entity().Add<Foo>();
 
             int count = 0;
-            r.Iter((Iter it) =>
+            r.Run((Iter it) =>
             {
-                Assert.True(it.GetVar("Var") == e);
-                count++;
+                while (it.Next())
+                {
+                    Assert.True(it.GetVar("Var") == e);
+                    count++;
+                }
             });
 
             Assert.Equal(1, count);
@@ -5090,12 +5161,15 @@ namespace Flecs.NET.Tests.Cpp
             Entity e = world.Entity().Add<Foo>();
 
             int count = 0;
-            r.Iter((Iter it) =>
+            r.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                Assert.Equal(e, it.Entity(0));
-                Assert.True(it.GetVar("Var") == world.Id<Foo>());
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    Assert.Equal(e, it.Entity(0));
+                    Assert.True(it.GetVar("Var") == world.Id<Foo>());
+                    count++;
+                }
             });
 
             Assert.Equal(1, count);
@@ -5116,12 +5190,15 @@ namespace Flecs.NET.Tests.Cpp
             Entity e = world.Entity().Add<Foo>(t);
 
             int count = 0;
-            r.Iter((Iter it) =>
+            r.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                Assert.Equal(e, it.Entity(0));
-                Assert.True(it.GetVar("Var") == t);
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    Assert.Equal(e, it.Entity(0));
+                    Assert.True(it.GetVar("Var") == t);
+                    count++;
+                }
             });
 
             Assert.Equal(1, count);
@@ -5144,12 +5221,15 @@ namespace Flecs.NET.Tests.Cpp
             Entity e = world.Entity().Add(foo, t);
 
             int count = 0;
-            r.Iter((Iter it) =>
+            r.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                Assert.Equal(e, it.Entity(0));
-                Assert.True(it.GetVar("Var") == t);
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    Assert.Equal(e, it.Entity(0));
+                    Assert.True(it.GetVar("Var") == t);
+                    count++;
+                }
             });
 
             Assert.Equal(1, count);
@@ -5170,12 +5250,15 @@ namespace Flecs.NET.Tests.Cpp
             Entity e = world.Entity().Add<Foo>(t);
 
             int count = 0;
-            r.Iter((Iter it) =>
+            r.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-                Assert.Equal(e, it.Entity(0));
-                Assert.True(it.GetVar("Var") == t);
-                count++;
+                while (it.Next())
+                {
+                    Assert.Equal(1, it.Count());
+                    Assert.Equal(e, it.Entity(0));
+                    Assert.True(it.GetVar("Var") == t);
+                    count++;
+                }
             });
 
             Assert.Equal(1, count);

--- a/src/Flecs.NET.Tests/Cpp/QueryTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/QueryTests.cs
@@ -565,12 +565,18 @@ namespace Flecs.NET.Tests.Cpp
 
             Query q = world.Query<Position, Velocity>();
 
-            q.Iter((Iter it, Field<Position> p, Field<Velocity> v) =>
+            q.Run((Iter it) =>
             {
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += v[i].X;
-                    p[i].Y += v[i].Y;
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[i].X;
+                        p[i].Y += v[i].Y;
+                    }
                 }
             });
 
@@ -593,12 +599,18 @@ namespace Flecs.NET.Tests.Cpp
 
             Query q = world.Query<Position, Velocity>();
 
-            q.Iter((Iter it, Field<Position> p, Field<Velocity> v) =>
+            q.Run((Iter it) =>
             {
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += v[i].X;
-                    p[i].Y += v[i].Y;
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[i].X;
+                        p[i].Y += v[i].Y;
+                    }
                 }
             });
 
@@ -630,22 +642,26 @@ namespace Flecs.NET.Tests.Cpp
                 .Expr("Velocity(self|up IsA)")
                 .Build();
 
-            q.Iter((Iter it, Field<Position> p) =>
+            q.Run((Iter it) =>
             {
-                Field<Velocity> v = it.Field<Velocity>(1);
+                while (it.Next())
+                {
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
 
-                if (!it.IsSelf(1))
-                    foreach (int i in it)
-                    {
-                        p[i].X += v[0].X;
-                        p[i].Y += v[0].Y;
-                    }
-                else
-                    foreach (int i in it)
-                    {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
-                    }
+                    if (!it.IsSelf(1))
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[0].X;
+                            p[i].Y += v[0].Y;
+                        }
+                    else
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                        }
+                }
             });
 
             Position* p = e1.GetPtr<Position>();
@@ -687,20 +703,27 @@ namespace Flecs.NET.Tests.Cpp
                 .TermAt(2).Optional()
                 .Build();
 
-            q.Iter((Iter it, Field<Position> p, Field<Velocity> v, Field<Mass> m) =>
+            q.Run((Iter it) =>
             {
-                if (it.IsSet(1) && it.IsSet(2))
-                    foreach (int i in it)
-                    {
-                        p[i].X += v[i].X * m[i].Value;
-                        p[i].Y += v[i].Y * m[i].Value;
-                    }
-                else
-                    foreach (int i in it)
-                    {
-                        p[i].X++;
-                        p[i].Y++;
-                    }
+                while (it.Next())
+                {
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
+                    Field<Mass> m = it.Field<Mass>(2);
+
+                    if (it.IsSet(1) && it.IsSet(2))
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X * m[i].Value;
+                            p[i].Y += v[i].Y * m[i].Value;
+                        }
+                    else
+                        foreach (int i in it)
+                        {
+                            p[i].X++;
+                            p[i].Y++;
+                        }
+                }
             });
 
             Position* p = e1.GetPtr<Position>();
@@ -889,15 +912,18 @@ namespace Flecs.NET.Tests.Cpp
 
             Query q = world.QueryBuilder().Expr("Position, Velocity").Build();
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Field<Position> p = it.Field<Position>(0);
-                Field<Velocity> v = it.Field<Velocity>(1);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += v[i].X;
-                    p[i].Y += v[i].Y;
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[i].X;
+                        p[i].Y += v[i].Y;
+                    }
                 }
             });
 
@@ -920,15 +946,18 @@ namespace Flecs.NET.Tests.Cpp
 
             Query q = world.QueryBuilder().Expr("Position, [in] Velocity").Build();
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Field<Position> p = it.Field<Position>(0);
-                Field<Velocity> v = it.Field<Velocity>(1);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += v[i].X;
-                    p[i].Y += v[i].Y;
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[i].X;
+                        p[i].Y += v[i].Y;
+                    }
                 }
             });
 
@@ -960,23 +989,26 @@ namespace Flecs.NET.Tests.Cpp
                 .Expr("Position, [in] Velocity(self|up IsA)")
                 .Build();
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Field<Position> p = it.Field<Position>(0);
-                Field<Velocity> v = it.Field<Velocity>(1);
+                while (it.Next())
+                {
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
 
-                if (!it.IsSelf(1))
-                    foreach (int i in it)
-                    {
-                        p[i].X += v[0].X;
-                        p[i].Y += v[0].Y;
-                    }
-                else
-                    foreach (int i in it)
-                    {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
-                    }
+                    if (!it.IsSelf(1))
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[0].X;
+                            p[i].Y += v[0].Y;
+                        }
+                    else
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                        }
+                }
             });
 
             Position* p = e1.GetPtr<Position>();
@@ -1015,24 +1047,27 @@ namespace Flecs.NET.Tests.Cpp
 
             Query q = world.QueryBuilder().Expr("Position, ?Velocity, ?Mass").Build();
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Field<Position> p = it.Field<Position>(0);
-                Field<Velocity> v = it.Field<Velocity>(1);
-                Field<Mass> m = it.Field<Mass>(2);
+                while (it.Next())
+                {
+                    Field<Position> p = it.Field<Position>(0);
+                    Field<Velocity> v = it.Field<Velocity>(1);
+                    Field<Mass> m = it.Field<Mass>(2);
 
-                if (it.IsSet(1) && it.IsSet(2))
-                    foreach (int i in it)
-                    {
-                        p[i].X += v[i].X * m[i].Value;
-                        p[i].Y += v[i].Y * m[i].Value;
-                    }
-                else
-                    foreach (int i in it)
-                    {
-                        p[i].X++;
-                        p[i].Y++;
-                    }
+                    if (it.IsSet(1) && it.IsSet(2))
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X * m[i].Value;
+                            p[i].Y += v[i].Y * m[i].Value;
+                        }
+                    else
+                        foreach (int i in it)
+                        {
+                            p[i].X++;
+                            p[i].Y++;
+                        }
+                }
             });
 
             Position* p = e1.GetPtr<Position>();
@@ -1067,13 +1102,16 @@ namespace Flecs.NET.Tests.Cpp
             int tableCount = 0;
             int entityCount = 0;
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                tableCount++;
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    Assert.True(it.Entity(i) == e2);
-                    entityCount++;
+                    tableCount++;
+                    foreach (int i in it)
+                    {
+                        Assert.True(it.Entity(i) == e2);
+                        entityCount++;
+                    }
                 }
             });
 
@@ -1132,14 +1170,18 @@ namespace Flecs.NET.Tests.Cpp
                 .OrderBy<Position>(ComparePosition)
                 .Build();
 
-            q.Iter((Iter it, Field<Position> p) =>
+            q.Run((Iter it) =>
             {
-                Assert.Equal(5, it.Count());
-                Assert.Equal(1, p[0].X);
-                Assert.Equal(2, p[1].X);
-                Assert.Equal(4, p[2].X);
-                Assert.Equal(5, p[3].X);
-                Assert.Equal(6, p[4].X);
+                while (it.Next())
+                {
+                    Field<Position> p = it.Field<Position>(0);
+                    Assert.Equal(5, it.Count());
+                    Assert.Equal(1, p[0].X);
+                    Assert.Equal(2, p[1].X);
+                    Assert.Equal(4, p[2].X);
+                    Assert.Equal(5, p[3].X);
+                    Assert.Equal(6, p[4].X);
+                }
             });
         }
 
@@ -1266,10 +1308,13 @@ namespace Flecs.NET.Tests.Cpp
                 .With<Tag>()
                 .Build();
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Assert.True(it.Id(0) == it.World().Id<Tag>());
-                Assert.True(it.Entity(0) == e);
+                while (it.Next())
+                {
+                    Assert.True(it.Id(0) == it.World().Id<Tag>());
+                    Assert.True(it.Entity(0) == e);
+                }
                 count++;
             });
 
@@ -1311,7 +1356,7 @@ namespace Flecs.NET.Tests.Cpp
         //         .With<Tag>()
         //         .Build();
         //
-        //     q.Iter((Iter it, Field<Value> v) =>
+        //     q.Run((Iter it, Field<Value> v) =>
         //     {
         //         foreach (int i in it)
         //         {
@@ -1535,7 +1580,11 @@ namespace Flecs.NET.Tests.Cpp
             Query q = world.Query<Position>();
 
             int count = 0;
-            q.Iter((Iter it) => { count += it.Count(); });
+            q.Run((Iter it) =>
+            {
+                while (it.Next())
+                    count += it.Count();
+            });
 
             Assert.Equal(3, count);
         }
@@ -1553,7 +1602,11 @@ namespace Flecs.NET.Tests.Cpp
             Query q = world.Query<Position, Velocity>();
 
             int count = 0;
-            q.Iter((Iter it) => { count += it.Count(); });
+            q.Run((Iter it) =>
+            {
+                while (it.Next())
+                    count += it.Count();
+            });
 
             Assert.Equal(2, count);
         }
@@ -1573,7 +1626,11 @@ namespace Flecs.NET.Tests.Cpp
                 .Build();
 
             int count = 0;
-            q.Iter((Iter it) => { count += it.Count(); });
+            q.Run((Iter it) =>
+            {
+                while (it.Next())
+                    count += it.Count();
+            });
 
             Assert.Equal(3, count);
         }
@@ -1606,10 +1663,13 @@ namespace Flecs.NET.Tests.Cpp
 
             Query q = world.Query<Position>();
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Assert.True(it.Type().Count() >= 1);
-                Assert.True(it.Table().Has<Position>());
+                while (it.Next())
+                {
+                    Assert.True(it.Type().Count() >= 1);
+                    Assert.True(it.Table().Has<Position>());
+                }
             });
         }
 
@@ -1934,16 +1994,23 @@ namespace Flecs.NET.Tests.Cpp
                 .Build();
 
             int count = 0;
-            q.Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+            q.Run((Iter it) =>
             {
-                Assert.True(it.Count() > 1);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += v[0].X;
-                    p[i].Y += v[0].Y;
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Position> p = it.Field<Position>(1);
+                    Field<Velocity> v = it.Field<Velocity>(2);
+
+                    Assert.True(it.Count() > 1);
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[0].X;
+                        p[i].Y += v[0].Y;
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -2007,25 +2074,32 @@ namespace Flecs.NET.Tests.Cpp
                 .Build();
 
             int count = 0;
-            q.Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+            q.Run((Iter it) =>
             {
-                Assert.True(it.Count() > 1);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    if (it.IsSelf(2))
-                    {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
-                    }
-                    else
-                    {
-                        p[i].X += v[0].X;
-                        p[i].Y += v[0].Y;
-                    }
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Position> p = it.Field<Position>(1);
+                    Field<Velocity> v = it.Field<Velocity>(2);
 
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Assert.True(it.Count() > 1);
+
+                    foreach (int i in it)
+                    {
+                        if (it.IsSelf(2))
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                        }
+                        else
+                        {
+                            p[i].X += v[0].X;
+                            p[i].Y += v[0].Y;
+                        }
+
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -2100,16 +2174,23 @@ namespace Flecs.NET.Tests.Cpp
                 .Build();
 
             int count = 0;
-            q.Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+            q.Run((Iter it) =>
             {
-                Assert.True(it.Count() == 1);
-
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += v[i].X;
-                    p[i].Y += v[i].Y;
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Position> p = it.Field<Position>(1);
+                    Field<Velocity> v = it.Field<Velocity>(2);
+
+                    Assert.True(it.Count() == 1);
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[i].X;
+                        p[i].Y += v[i].Y;
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -2172,14 +2253,21 @@ namespace Flecs.NET.Tests.Cpp
                 .Build();
 
             int count = 0;
-            q.Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+            q.Run((Iter it) =>
             {
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    p[i].X += v[i].X;
-                    p[i].Y += v[i].Y;
-                    Assert.True(it.Entity(i) == s[i].Value);
-                    count++;
+                    Field<Self> s = it.Field<Self>(0);
+                    Field<Position> p = it.Field<Position>(1);
+                    Field<Velocity> v = it.Field<Velocity>(2);
+
+                    foreach (int i in it)
+                    {
+                        p[i].X += v[i].X;
+                        p[i].Y += v[i].Y;
+                        Assert.True(it.Entity(i) == s[i].Value);
+                        count++;
+                    }
                 }
             });
 
@@ -2262,7 +2350,11 @@ namespace Flecs.NET.Tests.Cpp
             Assert.True(qc != null);
 
             int count = 0;
-            qc->Query.Iter((Iter it) => { count += it.Count(); });
+            qc->Query.Run((Iter it) =>
+            {
+                while (it.Next())
+                    count += it.Count();
+            });
             Assert.Equal(2, count);
         }
 
@@ -2508,7 +2600,7 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Each((Iter it, int row, ref Position p) =>
+            q.Each((Iter it, int row, ref Position _) =>
             {
                 ref Velocity v = ref it.FieldAt<Velocity>(1, row);
                 if (it.Entity(row) == e1)
@@ -2547,7 +2639,7 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q.Each((Iter it, int row, ref Position p) =>
+            q.Each((Iter it, int row, ref Position _) =>
             {
                 ref Velocity v = ref it.FieldAt<Velocity>(1, row);
                 if (it.Entity(row) == e1)
@@ -2581,24 +2673,27 @@ namespace Flecs.NET.Tests.Cpp
             world.Entity().Set(new Position(20, 30));
 
             Assert.True(qr.Changed());
-            qr.Iter((Iter it) => { });
+            qr.Run((Iter it) => { while (it.Next()) { } });
             Assert.False(qr.Changed());
 
             int count = 0, changeCount = 0;
 
-            qw.Iter((Iter it, Field<Position> p) =>
+            qw.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-
-                count++;
-
-                if (it.Entity(0) == e1)
+                while (it.Next())
                 {
-                    it.Skip();
-                    return;
-                }
+                    Assert.Equal(1, it.Count());
 
-                changeCount++;
+                    count++;
+
+                    if (it.Entity(0) == e1)
+                    {
+                        it.Skip();
+                        continue;
+                    }
+
+                    changeCount++;
+                }
             });
 
             Assert.Equal(2, count);
@@ -2609,20 +2704,23 @@ namespace Flecs.NET.Tests.Cpp
 
             Assert.True(qr.Changed());
 
-            qr.Iter((Iter it, Field<Position> p) =>
+            qr.Run((Iter it) =>
             {
-                Assert.Equal(1, it.Count());
-
-                count++;
-
-                if (it.Entity(0) == e1)
+                while (it.Next())
                 {
-                    Assert.False(it.Changed());
-                }
-                else
-                {
-                    Assert.True(it.Changed());
-                    changeCount++;
+                    Assert.Equal(1, it.Count());
+
+                    count++;
+
+                    if (it.Entity(0) == e1)
+                    {
+                        Assert.False(it.Changed());
+                    }
+                    else
+                    {
+                        Assert.True(it.Changed());
+                        changeCount++;
+                    }
                 }
             });
 
@@ -2681,13 +2779,19 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q2.Iter((Iter it2) =>
+            q2.Run((Iter it2) =>
             {
-                q1.Iter(it2, (Iter it1) =>
+                while (it2.Next())
                 {
-                    Assert.Equal(1, it1.Count());
-                    count += it1.Count();
-                });
+                    q1.Iter(it2).Run((Iter it1) =>
+                    {
+                        while (it1.Next())
+                        {
+                            Assert.Equal(1, it1.Count());
+                            count += it1.Count();
+                        }
+                    });
+                }
             });
 
             Assert.Equal(2, count);
@@ -2716,10 +2820,13 @@ namespace Flecs.NET.Tests.Cpp
 
             q2.Each((Entity e2) =>
             {
-                q1.Iter(e2, (Iter it1) =>
+                q1.Iter(e2).Run((Iter it1) =>
                 {
-                    Assert.Equal(1, it1.Count());
-                    count += it1.Count();
+                    while (it1.Next())
+                    {
+                        Assert.Equal(1, it1.Count());
+                        count += it1.Count();
+                    }
                 });
             });
 
@@ -2747,13 +2854,19 @@ namespace Flecs.NET.Tests.Cpp
 
             int count = 0;
 
-            q2.Iter((Iter it2) =>
+            q2.Run((Iter it2) =>
             {
-                q1.Iter(it2.World(), (Iter it1) =>
+                while (it2.Next())
                 {
-                    Assert.Equal(1, it1.Count());
-                    count += it1.Count();
-                });
+                    q1.Iter(it2.World()).Run((Iter it1) =>
+                    {
+                        while (it1.Next())
+                        {
+                            Assert.Equal(1, it1.Count());
+                            count += it1.Count();
+                        }
+                    });
+                }
             });
 
             Assert.Equal(2, count);
@@ -2845,14 +2958,17 @@ namespace Flecs.NET.Tests.Cpp
             Entity e3 = world.Entity().Set(new Position(10, 20));
 
             world.Query<Position>()
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(3, it.Count());
+                    while (it.Next())
+                    {
+                        Assert.Equal(3, it.Count());
 
-                    Field<ulong> entities = it.Entities();
-                    Assert.True(entities[0] == e1);
-                    Assert.True(entities[1] == e2);
-                    Assert.True(entities[2] == e3);
+                        Field<ulong> entities = it.Entities();
+                        Assert.True(entities[0] == e1);
+                        Assert.True(entities[1] == e2);
+                        Assert.True(entities[2] == e3);
+                    }
                 });
         }
 

--- a/src/Flecs.NET.Tests/Cpp/SingletonTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/SingletonTests.cs
@@ -42,7 +42,7 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Observer<Position>()
                 .Event(Ecs.OnSet)
-                .Iter((Iter it, Field<Position> p) => { invoked++; });
+                .Each((ref Position p) => { invoked++; });
 
             Entity e = world.Entity();
             e.Ensure<Position>();
@@ -61,7 +61,7 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Observer<Position>()
                 .Event(Ecs.OnAdd)
-                .Iter((Iter it, Field<Position> p) => { invoked++; });
+                .Each((ref Position p) => { invoked++; });
 
             world.Add<Position>();
 
@@ -78,7 +78,7 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Observer<Position>()
                 .Event(Ecs.OnRemove)
-                .Iter((Iter it, Field<Position> p) => { invoked++; });
+                .Each((ref Position p) => { invoked++; });
 
             world.Ensure<Position>();
             Assert.Equal(0, invoked);
@@ -108,14 +108,17 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .Expr("[inout] Position($)")
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Field<Position> p = it.Field<Position>(0);
-                    Assert.Equal(10, p[0].X);
-                    Assert.Equal(20, p[0].Y);
+                    while (it.Next())
+                    {
+                        Field<Position> p = it.Field<Position>(0);
+                        Assert.Equal(10, p[0].X);
+                        Assert.Equal(20, p[0].Y);
 
-                    p[0].X++;
-                    p[0].Y++;
+                        p[0].X++;
+                        p[0].Y++;
+                    }
                 });
 
             world.Progress();

--- a/src/Flecs.NET.Tests/Cpp/SystemBuilderTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/SystemBuilderTests.cs
@@ -323,19 +323,23 @@ namespace Flecs.NET.Tests.Cpp
 
             Routine s = world.Routine<Entity>()
                 .With<Singleton>().Singleton()
-                .Iter((Iter it, Field<Entity> e) =>
+                .Run((Iter it) =>
                 {
-                    Field<Singleton> s = it.Field<Singleton>(1);
-                    Assert.True(!it.IsSelf(1));
-                    Assert.Equal(10, s[0].Value);
-
-                    ref Singleton sRef = ref s[0];
-                    Assert.Equal(10, sRef.Value);
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        Assert.True(it.Entity(i) == e[i]);
-                        count++;
+                        Field<Entity> e = it.Field<Entity>(0);
+                        Field<Singleton> s = it.Field<Singleton>(1);
+                        Assert.True(!it.IsSelf(1));
+                        Assert.Equal(10, s[0].Value);
+
+                        ref Singleton sRef = ref s[0];
+                        Assert.Equal(10, sRef.Value);
+
+                        foreach (int i in it)
+                        {
+                            Assert.True(it.Entity(i) == e[i]);
+                            count++;
+                        }
                     }
                 });
 
@@ -381,12 +385,15 @@ namespace Flecs.NET.Tests.Cpp
                 .With<TagH>()
                 .With<TagI>()
                 .With<TagJ>()
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(1, it.Count());
-                    Assert.True(it.Entity(0) == e);
-                    Assert.Equal(10, it.FieldCount());
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(1, it.Count());
+                        Assert.True(it.Entity(0) == e);
+                        Assert.Equal(10, it.FieldCount());
+                        count++;
+                    }
                 });
 
             s.Run();
@@ -436,12 +443,15 @@ namespace Flecs.NET.Tests.Cpp
                 .With<TagN>()
                 .With<TagO>()
                 .With<TagP>()
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(1, it.Count());
-                    Assert.True(it.Entity(0) == e);
-                    Assert.Equal(16, it.FieldCount());
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(1, it.Count());
+                        Assert.True(it.Entity(0) == e);
+                        Assert.Equal(16, it.FieldCount());
+                        count++;
+                    }
                 });
 
             s.Run();
@@ -456,7 +466,10 @@ namespace Flecs.NET.Tests.Cpp
 
             Routine s = world.Routine<Position>("MySystem")
                 .TermAt(0).Src().Name("MySystem")
-                .Iter((Iter it, Field<Position> p) => { });
+                .Run((Iter it) =>
+                {
+                    while (it.Next()) { }
+                });
 
             Assert.True(s.Entity.Has<Position>());
         }

--- a/src/Flecs.NET.Tests/Cpp/SystemTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/SystemTests.cs
@@ -24,12 +24,18 @@ namespace Flecs.NET.Tests.Cpp
                 .Set(new Velocity(1, 2));
 
             world.Routine<Position, Velocity>()
-                .Iter((Iter it, Field<Position> p, Field<Velocity> v) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
+
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                        }
                     }
                 });
 
@@ -54,12 +60,18 @@ namespace Flecs.NET.Tests.Cpp
                 .Set(new Velocity(1, 2));
 
             world.Routine<Position, Velocity>()
-                .Iter((Iter it, Field<Position> p, Field<Velocity> v) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
+
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                        }
                     }
                 });
 
@@ -91,22 +103,26 @@ namespace Flecs.NET.Tests.Cpp
                 .Set(new Velocity(3, 4));
 
             world.Routine<Position>().Expr("Velocity(self|up IsA)")
-                .Iter((Iter it, Field<Position> p) =>
+                .Run((Iter it) =>
                 {
-                    Field<Velocity> v = it.Field<Velocity>(1);
+                    while (it.Next())
+                    {
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
 
-                    if (!it.IsSelf(1))
-                        foreach (int i in it)
-                        {
-                            p[i].X += v[0].X;
-                            p[i].Y += v[0].Y;
-                        }
-                    else
-                        foreach (int i in it)
-                        {
-                            p[i].X += v[i].X;
-                            p[i].Y += v[i].Y;
-                        }
+                        if (!it.IsSelf(1))
+                            foreach (int i in it)
+                            {
+                                p[i].X += v[0].X;
+                                p[i].Y += v[0].Y;
+                            }
+                        else
+                            foreach (int i in it)
+                            {
+                                p[i].X += v[i].X;
+                                p[i].Y += v[i].Y;
+                            }
+                    }
                 });
 
             world.Progress();
@@ -145,20 +161,27 @@ namespace Flecs.NET.Tests.Cpp
             world.Routine<Position, Velocity, Mass>()
                 .TermAt(1).Optional()
                 .TermAt(2).Optional()
-                .Iter((Iter it, Field<Position> p, Field<Velocity> v, Field<Mass> m) =>
+                .Run((Iter it) =>
                 {
-                    if (it.IsSet(1) && it.IsSet(2))
-                        foreach (int i in it)
-                        {
-                            p[i].X += v[i].X * m[i].Value;
-                            p[i].Y += v[i].Y * m[i].Value;
-                        }
-                    else
-                        foreach (int i in it)
-                        {
-                            p[i].X++;
-                            p[i].Y++;
-                        }
+                    while (it.Next())
+                    {
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
+                        Field<Mass> m = it.Field<Mass>(2);
+
+                        if (it.IsSet(1) && it.IsSet(2))
+                            foreach (int i in it)
+                            {
+                                p[i].X += v[i].X * m[i].Value;
+                                p[i].Y += v[i].Y * m[i].Value;
+                            }
+                        else
+                            foreach (int i in it)
+                            {
+                                p[i].X++;
+                                p[i].Y++;
+                            }
+                    }
                 });
 
             world.Progress();
@@ -328,15 +351,18 @@ namespace Flecs.NET.Tests.Cpp
                 .Set(new Velocity(1, 2));
 
             world.Routine().Expr("Position, Velocity")
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Field<Position> p = it.Field<Position>(0);
-                    Field<Velocity> v = it.Field<Velocity>(1);
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
+
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                        }
                     }
                 });
 
@@ -361,15 +387,18 @@ namespace Flecs.NET.Tests.Cpp
                 .Set(new Velocity(1, 2));
 
             world.Routine().Expr("Position, [in] Velocity")
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Field<Position> p = it.Field<Position>(0);
-                    Field<Velocity> v = it.Field<Velocity>(1);
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
+
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                        }
                     }
                 });
 
@@ -401,23 +430,26 @@ namespace Flecs.NET.Tests.Cpp
                 .Set(new Velocity(3, 4));
 
             world.Routine().Expr("Position, [in] Velocity(self|up IsA)")
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Field<Position> p = it.Field<Position>(0);
-                    Field<Velocity> v = it.Field<Velocity>(1);
+                    while (it.Next())
+                    {
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
 
-                    if (!it.IsSelf(1))
-                        foreach (int i in it)
-                        {
-                            p[i].X += v[0].X;
-                            p[i].Y += v[0].Y;
-                        }
-                    else
-                        foreach (int i in it)
-                        {
-                            p[i].X += v[i].X;
-                            p[i].Y += v[i].Y;
-                        }
+                        if (!it.IsSelf(1))
+                            foreach (int i in it)
+                            {
+                                p[i].X += v[0].X;
+                                p[i].Y += v[0].Y;
+                            }
+                        else
+                            foreach (int i in it)
+                            {
+                                p[i].X += v[i].X;
+                                p[i].Y += v[i].Y;
+                            }
+                    }
                 });
 
             world.Progress();
@@ -454,24 +486,27 @@ namespace Flecs.NET.Tests.Cpp
                 .Set(new Position(70, 80));
 
             world.Routine().Expr("Position, ?Velocity, ?Mass")
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Field<Position> p = it.Field<Position>(0);
-                    Field<Velocity> v = it.Field<Velocity>(1);
-                    Field<Mass> m = it.Field<Mass>(2);
+                    while (it.Next())
+                    {
+                        Field<Position> p = it.Field<Position>(0);
+                        Field<Velocity> v = it.Field<Velocity>(1);
+                        Field<Mass> m = it.Field<Mass>(2);
 
-                    if (it.IsSet(1) && it.IsSet(2))
-                        foreach (int i in it)
-                        {
-                            p[i].X += v[i].X * m[i].Value;
-                            p[i].Y += v[i].Y * m[i].Value;
-                        }
-                    else
-                        foreach (int i in it)
-                        {
-                            p[i].X++;
-                            p[i].Y++;
-                        }
+                        if (it.IsSet(1) && it.IsSet(2))
+                            foreach (int i in it)
+                            {
+                                p[i].X += v[i].X * m[i].Value;
+                                p[i].Y += v[i].Y * m[i].Value;
+                            }
+                        else
+                            foreach (int i in it)
+                            {
+                                p[i].X++;
+                                p[i].Y++;
+                            }
+                    }
                 });
 
             world.Progress();
@@ -501,11 +536,11 @@ namespace Flecs.NET.Tests.Cpp
             string name = "Hello";
 
             Routine system1 = world.Routine<Position>(name)
-                .Iter((Iter it, Field<Position> p) => { });
+                .Run((Iter it) => { while (it.Next()) { } });
 
             name = "World";
             Routine system2 = world.Routine<Position>(name)
-                .Iter((Iter it, Field<Position> p) => { });
+                .Run((Iter it) => { while (it.Next()) { } });
 
             Assert.True(system1.Id != system2.Id);
         }
@@ -516,7 +551,7 @@ namespace Flecs.NET.Tests.Cpp
             using World world = World.Create();
 
             Routine system1 = world.Routine<Position>("foo.bar")
-                .Iter((Iter it, Field<Position> p) => { });
+                .Run((Iter it) => { while (it.Next()) { } });
 
             Assert.Equal("bar", system1.Entity.Name());
 
@@ -537,7 +572,11 @@ namespace Flecs.NET.Tests.Cpp
             int count = 0;
 
             world.Routine()
-                .Iter((Iter it) => { count++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        count++;
+                });
 
             world.Progress();
 
@@ -552,7 +591,11 @@ namespace Flecs.NET.Tests.Cpp
             int invoked = 0;
 
             world.Routine<MyTag>()
-                .Iter((Iter it) => { invoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        invoked++;
+                });
 
             world.Entity()
                 .Add<MyTag>();
@@ -588,7 +631,7 @@ namespace Flecs.NET.Tests.Cpp
             Routine sys = world.Routine()
                 .Kind(0)
                 .Interval(1.0f)
-                .Iter((Iter it) => { });
+                .Run((Iter it) => { });
 
             float i = sys.Interval();
             Assert.Equal(1.0f, i);
@@ -747,20 +790,20 @@ namespace Flecs.NET.Tests.Cpp
             int count = 0;
 
             Routine sys = world.Routine<Position>()
-                .Each((Entity e, ref Position p) =>
-                {
-                    // Not used
-                });
+                .Each((Entity e, ref Position p) => { });
 
             Query q = sys.Query();
 
-            q.Iter((Iter it) =>
+            q.Run((Iter it) =>
             {
-                Field<Position> pos = it.Field<Position>(0);
-                foreach (int i in it)
+                while (it.Next())
                 {
-                    Assert.Equal(i, pos[i].X);
-                    count++;
+                    Field<Position> pos = it.Field<Position>(0);
+                    foreach (int i in it)
+                    {
+                        Assert.Equal(i, pos[i].X);
+                        count++;
+                    }
                 }
             });
 
@@ -780,7 +823,6 @@ namespace Flecs.NET.Tests.Cpp
                 .Each((Entity e, ref Position p) =>
                 {
                     e.Add<Velocity>();
-                    // Add is deferred
                     Assert.True(!e.Has<Velocity>());
                 });
 
@@ -804,7 +846,6 @@ namespace Flecs.NET.Tests.Cpp
                 .Each((Entity e, ref Position p) =>
                 {
                     e.Destruct();
-                    // Delete is deferred
                     Assert.True(e.IsAlive());
                 });
 
@@ -872,12 +913,17 @@ namespace Flecs.NET.Tests.Cpp
             Entity e3 = world.Entity().Set(new Position(2, 0));
 
             world.Routine<Position>()
-                .Iter((Iter it, Field<Position> p) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        it.Entity(i).Add<Velocity>();
-                        Assert.True(!it.Entity(i).Has<Velocity>());
+                        Field<Position> p = it.Field<Position>(0);
+
+                        foreach (int i in it)
+                        {
+                            it.Entity(i).Add<Velocity>();
+                            Assert.True(!it.Entity(i).Has<Velocity>());
+                        }
                     }
                 });
 
@@ -898,13 +944,17 @@ namespace Flecs.NET.Tests.Cpp
             Entity e3 = world.Entity().Set(new Position(2, 0));
 
             world.Routine<Position>()
-                .Iter((Iter it, Field<Position> p) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        it.Entity(i).Destruct();
-                        // Delete is deferred
-                        Assert.True(it.Entity(i).IsAlive());
+                        Field<Position> p = it.Field<Position>(0);
+
+                        foreach (int i in it)
+                        {
+                            it.Entity(i).Destruct();
+                            Assert.True(it.Entity(i).IsAlive());
+                        }
                     }
                 });
 
@@ -925,9 +975,15 @@ namespace Flecs.NET.Tests.Cpp
             Entity e3 = world.Entity().Set(new EntityWrapper(world.Entity()));
 
             world.Routine<EntityWrapper>()
-                .Iter((Iter it, Field<EntityWrapper> c) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it) c[i].Value.Mut(it).Add<Position>();
+                    while (it.Next())
+                    {
+                        Field<EntityWrapper> c = it.Field<EntityWrapper>(0);
+
+                        foreach (int i in it)
+                            c[i].Value.Mut(it).Add<Position>();
+                    }
                 });
 
             world.Progress();
@@ -947,12 +1003,19 @@ namespace Flecs.NET.Tests.Cpp
             Entity e3 = world.Entity().Set(new Position(0, 0));
 
             world.Routine<Position>()
-                .Iter((Iter it, Field<Position> p) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
-                        it.Entity(i).Set(new EntityWrapper(
-                            it.World().Entity().Add<Velocity>()
-                        ));
+                    while (it.Next())
+                    {
+                        Field<Position> p = it.Field<Position>(0);
+
+                        foreach (int i in it)
+                        {
+                            it.Entity(i).Set(new EntityWrapper(
+                                it.World().Entity().Add<Velocity>()
+                            ));
+                        }
+                    }
                 });
 
             world.Progress();
@@ -979,14 +1042,21 @@ namespace Flecs.NET.Tests.Cpp
             int count = 0;
 
             world.Routine<Position>()
-                .Iter((Iter it, Field<Position> p) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
-                        it.Entity(i).Children((Entity child) =>
+                    while (it.Next())
+                    {
+                        Field<Position> p = it.Field<Position>(0);
+
+                        foreach (int i in it)
                         {
-                            child.Add<Velocity>();
-                            count++;
-                        });
+                            it.Entity(i).Children((Entity child) =>
+                            {
+                                child.Add<Velocity>();
+                                count++;
+                            });
+                        }
+                    }
                 });
 
             world.Progress();
@@ -1012,18 +1082,24 @@ namespace Flecs.NET.Tests.Cpp
             int count = 0;
 
             world.Routine<EntityWrapper>()
-                .Iter((Iter it, Field<EntityWrapper> c) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
-                        c[i].Value.Children((Entity child) =>
-                        {
-                            // Dummy code to ensure we can access the entity
-                            Position* p = child.GetPtr<Position>();
-                            Assert.Equal(1, p->X);
-                            Assert.Equal(0, p->Y);
+                    while (it.Next())
+                    {
+                        Field<EntityWrapper> c = it.Field<EntityWrapper>(0);
 
-                            count++;
-                        });
+                        foreach (int i in it)
+                        {
+                            c[i].Value.Children((Entity child) =>
+                            {
+                                Position* p = child.GetPtr<Position>();
+                                Assert.Equal(1, p->X);
+                                Assert.Equal(0, p->Y);
+
+                                count++;
+                            });
+                        }
+                    }
                 });
 
             world.Progress();
@@ -1052,27 +1128,51 @@ namespace Flecs.NET.Tests.Cpp
                 frameCount = 0;
 
             Routine root = world.Routine("root")
-                .Iter((Iter it) => { rootCount++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        rootCount++;
+                });
 
             Routine l1A = world.Routine("l1_a")
                 .Rate(root, 1)
-                .Iter((Iter it) => { l1ACount++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        l1ACount++;
+                });
 
             Routine l1B = world.Routine("l1_b")
                 .Rate(root, 2)
-                .Iter((Iter it) => { l1BCount++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        l1BCount++;
+                });
 
             world.Routine("l1_c")
                 .Rate(root, 3)
-                .Iter((Iter it) => { l1CCount++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        l1CCount++;
+                });
 
             world.Routine("l2_a")
                 .Rate(l1A, 2)
-                .Iter((Iter it) => { l2ACount++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        l2ACount++;
+                });
 
             world.Routine("l2_b")
                 .Rate(l1B, 2)
-                .Iter((Iter it) => { l2BCount++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        l2BCount++;
+                });
 
             for (int i = 0; i < 30; i++)
             {
@@ -1102,15 +1202,25 @@ namespace Flecs.NET.Tests.Cpp
                 frameCount = 0;
 
             Routine root = world.Routine("root")
-                .Iter((Iter it) => { rootCount++; });
+                .Run((Iter it) => {
+                    while (it.Next())
+                        rootCount++; });
 
             Routine l1 = world.Routine("l1")
                 .Rate(root, 2)
-                .Iter((Iter it) => { l1Count++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        l1Count++;
+                });
 
             world.Routine("l2")
                 .Rate(l1, 3)
-                .Iter((Iter it) => { l2Count++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        l2Count++;
+                });
 
             for (int i = 0; i < 12; i++)
             {
@@ -1121,7 +1231,7 @@ namespace Flecs.NET.Tests.Cpp
                 Assert.Equal(l2Count, frameCount / l2Mult);
             }
 
-            l1.Rate(4); // Run twice as slow
+            l1.Rate(4);
             l1Mult *= 2;
             l2Mult *= 2;
 
@@ -1183,12 +1293,17 @@ namespace Flecs.NET.Tests.Cpp
 
             Routine s = world.Routine<Value>()
                 .With<Tag>()
-                .Iter((Iter it, Field<Value> v) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        v[i].Number++;
-                        it.Entity(i).Remove<Tag>();
+                        Field<Value> v = it.Field<Value>(0);
+
+                        foreach (int i in it)
+                        {
+                            v[i].Number++;
+                            it.Entity(i).Remove<Tag>();
+                        }
                     }
                 });
 
@@ -1227,28 +1342,37 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .Kind(postFrame)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(2, count);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(2, count);
+                        count++;
+                    }
                 })
                 .Entity.Add(tag);
 
             world.Routine()
                 .Kind(onFrame)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(1, count);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(1, count);
+                        count++;
+                    }
                 })
                 .Entity.Add(tag);
 
             world.Routine()
                 .Kind(preFrame)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(0, count);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(0, count);
+                        count++;
+                    }
                 })
                 .Entity.Add(tag);
 
@@ -1277,26 +1401,35 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .Kind(tag)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(0, count);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(0, count);
+                        count++;
+                    }
                 });
 
             world.Routine()
                 .Kind(tag)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(1, count);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(1, count);
+                        count++;
+                    }
                 });
 
             world.Routine()
                 .Kind(tag)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.Equal(2, count);
-                    count++;
+                    while (it.Next())
+                    {
+                        Assert.Equal(2, count);
+                        count++;
+                    }
                 });
 
             Assert.Equal(0, count);
@@ -1631,16 +1764,23 @@ namespace Flecs.NET.Tests.Cpp
             Routine s = world.Routine<Self, Position, Velocity>()
                 .TermAt(2).Singleton()
                 .Instanced()
-                .Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+                .Run((Iter it) =>
                 {
-                    Assert.True(it.Count() > 1);
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        p[i].X += v[0].X;
-                        p[i].Y += v[0].Y;
-                        Assert.True(it.Entity(i) == s[i].Value);
-                        count++;
+                        Field<Self> s = it.Field<Self>(0);
+                        Field<Position> p = it.Field<Position>(1);
+                        Field<Velocity> v = it.Field<Velocity>(2);
+
+                        Assert.True(it.Count() > 1);
+
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[0].X;
+                            p[i].Y += v[0].Y;
+                            Assert.True(it.Entity(i) == s[i].Value);
+                            count++;
+                        }
                     }
                 });
 
@@ -1705,25 +1845,32 @@ namespace Flecs.NET.Tests.Cpp
 
             Routine s = world.Routine<Self, Position, Velocity>()
                 .Instanced()
-                .Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+                .Run((Iter it) =>
                 {
-                    Assert.True(it.Count() > 1);
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        if (it.IsSelf(2))
-                        {
-                            p[i].X += v[i].X;
-                            p[i].Y += v[i].Y;
-                        }
-                        else
-                        {
-                            p[i].X += v[0].X;
-                            p[i].Y += v[0].Y;
-                        }
+                        Field<Self> s = it.Field<Self>(0);
+                        Field<Position> p = it.Field<Position>(1);
+                        Field<Velocity> v = it.Field<Velocity>(2);
 
-                        Assert.True(it.Entity(i) == s[i].Value);
-                        count++;
+                        Assert.True(it.Count() > 1);
+
+                        foreach (int i in it)
+                        {
+                            if (it.IsSelf(2))
+                            {
+                                p[i].X += v[i].X;
+                                p[i].Y += v[i].Y;
+                            }
+                            else
+                            {
+                                p[i].X += v[0].X;
+                                p[i].Y += v[0].Y;
+                            }
+
+                            Assert.True(it.Entity(i) == s[i].Value);
+                            count++;
+                        }
                     }
                 });
 
@@ -1799,16 +1946,23 @@ namespace Flecs.NET.Tests.Cpp
 
             Routine s = world.Routine<Self, Position, Velocity>()
                 .TermAt(2).Singleton()
-                .Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+                .Run((Iter it) =>
                 {
-                    Assert.True(it.Count() == 1);
-
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
-                        Assert.True(it.Entity(i) == s[i].Value);
-                        count++;
+                        Field<Self> s = it.Field<Self>(0);
+                        Field<Position> p = it.Field<Position>(1);
+                        Field<Velocity> v = it.Field<Velocity>(2);
+
+                        Assert.True(it.Count() == 1);
+
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                            Assert.True(it.Entity(i) == s[i].Value);
+                            count++;
+                        }
                     }
                 });
 
@@ -1872,14 +2026,21 @@ namespace Flecs.NET.Tests.Cpp
             int count = 0;
 
             Routine s = world.Routine<Self, Position, Velocity>()
-                .Iter((Iter it, Field<Self> s, Field<Position> p, Field<Velocity> v) =>
+                .Run((Iter it) =>
                 {
-                    foreach (int i in it)
+                    while (it.Next())
                     {
-                        p[i].X += v[i].X;
-                        p[i].Y += v[i].Y;
-                        Assert.True(it.Entity(i) == s[i].Value);
-                        count++;
+                        Field<Self> s = it.Field<Self>(0);
+                        Field<Position> p = it.Field<Position>(1);
+                        Field<Velocity> v = it.Field<Velocity>(2);
+
+                        foreach (int i in it)
+                        {
+                            p[i].X += v[i].X;
+                            p[i].Y += v[i].Y;
+                            Assert.True(it.Entity(i) == s[i].Value);
+                            count++;
+                        }
                     }
                 });
 
@@ -2035,7 +2196,11 @@ namespace Flecs.NET.Tests.Cpp
             int invoked = 0;
 
             Entity sys = world.Routine()
-                .Iter((Iter it) => { invoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        invoked++;
+                });
 
             Routine sysFromId = world.Routine(sys);
 
@@ -2087,7 +2252,7 @@ namespace Flecs.NET.Tests.Cpp
                 {
                     Position temp = p;
 
-                    q.Each(e, (ref Velocity v) =>
+                    q.Iter(e).Each((ref Velocity v) =>
                     {
                         temp.X += v.X;
                         temp.Y += v.Y;
@@ -2122,7 +2287,7 @@ namespace Flecs.NET.Tests.Cpp
                 {
                     Position temp = p;
 
-                    q.Each(it, (ref Velocity v) =>
+                    q.Iter(it).Each((ref Velocity v) =>
                     {
                         temp.X += v.X;
                         temp.Y += v.Y;
@@ -2157,7 +2322,7 @@ namespace Flecs.NET.Tests.Cpp
                 {
                     Position temp = p;
 
-                    q.Each(it.World(), (ref Velocity v) =>
+                    q.Iter(it.World()).Each((ref Velocity v) =>
                     {
                         temp.X += v.X;
                         temp.Y += v.Y;
@@ -2192,12 +2357,17 @@ namespace Flecs.NET.Tests.Cpp
                 {
                     Position temp = p;
 
-                    q.Iter(e, (Iter it, Field<Velocity> v) =>
+                    q.Iter(e).Run((Iter it) =>
                     {
-                        foreach (int i in it)
+                        while (it.Next())
                         {
-                            temp.X += v[i].X;
-                            temp.Y += v[i].Y;
+                            Field<Velocity> v = it.Field<Velocity>(0);
+
+                            foreach (int i in it)
+                            {
+                                temp.X += v[i].X;
+                                temp.Y += v[i].Y;
+                            }
                         }
                     });
 
@@ -2230,12 +2400,17 @@ namespace Flecs.NET.Tests.Cpp
                 {
                     Position temp = p;
 
-                    q.Iter(it, (Iter it, Field<Velocity> v) =>
+                    q.Iter(it).Run((Iter it) =>
                     {
-                        foreach (int i in it)
+                        while (it.Next())
                         {
-                            temp.X += v[i].X;
-                            temp.Y += v[i].Y;
+                            Field<Velocity> v = it.Field<Velocity>(0);
+
+                            foreach (int i in it)
+                            {
+                                temp.X += v[i].X;
+                                temp.Y += v[i].Y;
+                            }
                         }
                     });
 
@@ -2268,12 +2443,17 @@ namespace Flecs.NET.Tests.Cpp
                 {
                     Position temp = p;
 
-                    q.Iter(it.World(), (Iter it, Field<Velocity> v) =>
+                    q.Iter(it.World()).Run((Iter it) =>
                     {
-                        foreach (int i in it)
+                        while (it.Next())
                         {
-                            temp.X += v[i].X;
-                            temp.Y += v[i].Y;
+                            Field<Velocity> v = it.Field<Velocity>(0);
+
+                            foreach (int i in it)
+                            {
+                                temp.X += v[i].X;
+                                temp.Y += v[i].Y;
+                            }
                         }
                     });
 
@@ -2287,44 +2467,39 @@ namespace Flecs.NET.Tests.Cpp
             Assert.Equal(22, p->Y);
         }
 
-        // TODO: Doesn't work in release mode.
-        // [Fact]
-        // private void RunCallback()
-        // {
-        //     using World world = World.Create();
-        //
-        //     Entity entity = world.Entity()
-        //         .Set(new Position(10, 20))
-        //         .Set(new Velocity(1, 2));
-        //
-        //     world.Routine<Position, Velocity>()
-        //         .Run((ecs_iter_t* it) =>
-        //         {
-        //             while (ecs_iter_next(it) == 1)
-        //             {
-        //                 Ecs.IterAction callback = Marshal.GetDelegateForFunctionPointer<Ecs.IterAction>(it->callback);
-        //                 callback(it);
-        //             }
-        //         })
-        //         .Iter((Iter it, Field<Position> p, Field<Velocity> v) =>
-        //         {
-        //             foreach (int i in it)
-        //             {
-        //                 p[i].X += v[i].X;
-        //                 p[i].Y += v[i].Y;
-        //             }
-        //         });
-        //
-        //     world.Progress();
-        //
-        //     Position* p = entity.GetPtr<Position>();
-        //     Assert.Equal(11, p->X);
-        //     Assert.Equal(22, p->Y);
-        //
-        //     Velocity* v = entity.GetPtr<Velocity>();
-        //     Assert.Equal(1, v->X);
-        //     Assert.Equal(2, v->Y);
-        // }
+        [Fact]
+        private void RunCallback()
+        {
+            using World world = World.Create();
+
+            Entity entity = world.Entity()
+                .Set(new Position(10, 20))
+                .Set(new Velocity(1, 2));
+
+            world.Routine<Position, Velocity>()
+                .Run(
+                    (Iter it) =>
+                    {
+                        while (it.Next())
+                            it.Callback();
+                    },
+                    (ref Position p, ref Velocity v) =>
+                    {
+                            p.X += v.X;
+                            p.Y += v.Y;
+                    }
+                );
+
+            world.Progress();
+
+            Position* p = entity.GetPtr<Position>();
+            Assert.Equal(11, p->X);
+            Assert.Equal(22, p->Y);
+
+            Velocity* v = entity.GetPtr<Velocity>();
+            Assert.Equal(1, v->X);
+            Assert.Equal(2, v->Y);
+        }
 
         [Fact]
         private void StartupSystem()
@@ -2335,18 +2510,24 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .Kind(Ecs.OnStart)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.True(it.DeltaTime() == 0);
-                    countA++;
+                    while (it.Next())
+                    {
+                        Assert.True(it.DeltaTime() == 0);
+                        countA++;
+                    }
                 });
 
             world.Routine()
                 .Kind(Ecs.OnUpdate)
-                .Iter((Iter it) =>
+                .Run((Iter it) =>
                 {
-                    Assert.True(it.DeltaTime() != 0);
-                    countB++;
+                    while (it.Next())
+                    {
+                        Assert.True(it.DeltaTime() != 0);
+                        countB++;
+                    }
                 });
 
             world.Progress();
@@ -2372,11 +2553,19 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .TickSource(t)
-                .Iter((Iter it) => { sysAInvoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        sysAInvoked++;
+                });
 
             world.Routine()
                 .TickSource(t)
-                .Iter((Iter it) => { sysBInvoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        sysBInvoked++;
+                });
 
             world.Progress(1.0f);
             Assert.Equal(0, sysAInvoked);
@@ -2402,11 +2591,19 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .TickSource(t)
-                .Iter((Iter it) => { sysAInvoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        sysAInvoked++;
+                });
 
             world.Routine()
                 .TickSource(t)
-                .Iter((Iter it) => { sysBInvoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        sysBInvoked++;
+                });
 
             world.Progress(1.0f);
             Assert.Equal(0, sysAInvoked);
@@ -2433,11 +2630,19 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .TickSource(t3)
-                .Iter((Iter it) => { sysAInvoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        sysAInvoked++;
+                });
 
             world.Routine()
                 .TickSource(t6)
-                .Iter((Iter it) => { sysBInvoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        sysBInvoked++;
+                });
 
             world.Progress(1.0f);
             Assert.Equal(0, sysAInvoked);
@@ -2533,7 +2738,7 @@ namespace Flecs.NET.Tests.Cpp
 
             Entity s1 = world.Routine()
                 .Interval(1.0f)
-                .Iter((Iter it) => { });
+                .Run((Iter it) => { while (it.Next()) { } });
 
             {
                 EcsTimer* t = s1.GetPtr<EcsTimer>();
@@ -2545,7 +2750,7 @@ namespace Flecs.NET.Tests.Cpp
 
             Entity s2 = world.Routine()
                 .Interval(1.0f)
-                .Iter((Iter it) => { });
+                .Run((Iter it) => { while (it.Next()) { } });
 
             {
                 EcsTimer* t = s1.GetPtr<EcsTimer>();
@@ -2571,7 +2776,11 @@ namespace Flecs.NET.Tests.Cpp
 
             world.Routine()
                 .TickSource<TagA>()
-                .Iter((Iter it) => { sysInvoked++; });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        sysInvoked++;
+                });
 
             world.Progress(1.0f);
             Assert.Equal(0, sysInvoked);
@@ -2592,7 +2801,11 @@ namespace Flecs.NET.Tests.Cpp
 
             bool ranTest = false;
 
-            world.Routine().Kind(PipelineStepEnum.CustomStep).Iter((Iter it) => { ranTest = true; });
+            world.Routine().Kind(PipelineStepEnum.CustomStep).Run((Iter it) =>
+            {
+                while (it.Next())
+                    ranTest = true;
+            });
 
             world.Progress();
             Assert.True(ranTest);
@@ -2608,7 +2821,11 @@ namespace Flecs.NET.Tests.Cpp
 
             bool ranTest = false;
 
-            world.Routine().Kind(PipelineStepEnum.CustomStep2).Iter((Iter it) => { ranTest = true; });
+            world.Routine().Kind(PipelineStepEnum.CustomStep2).Run((Iter it) =>
+            {
+                while (it.Next())
+                    ranTest = true;
+            });
 
             world.Progress();
             Assert.True(ranTest);

--- a/src/Flecs.NET.Tests/Cpp/TableTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/TableTests.cs
@@ -44,7 +44,11 @@ namespace Flecs.NET.Tests.Cpp
             Entity e2 = world.Entity().Add<Velocity>();
 
             world.Query<Position>()
-                .Iter((Iter it, Field<Position> p) => { e2.Add<Mass>(); });
+                .Run((Iter it) =>
+                {
+                    while (it.Next())
+                        e2.Add<Mass>();
+                });
 
             Assert.True(e2.Has<Mass>());
         }
@@ -58,7 +62,10 @@ namespace Flecs.NET.Tests.Cpp
             Entity e2 = world.Entity().Add<Velocity>();
 
             world.Query<Position>()
-                .Iter((Iter it) => { e2.Add<Mass>(); });
+                .Run((Iter it) => {
+                    while (it.Next())
+                        e2.Add<Mass>();
+                });
 
             Assert.True(e2.Has<Mass>());
         }

--- a/src/Flecs.NET.Tests/Cpp/UnionTests.cs
+++ b/src/Flecs.NET.Tests/Cpp/UnionTests.cs
@@ -1,0 +1,144 @@
+using Flecs.NET.Core;
+using Xunit;
+
+namespace Flecs.NET.Tests.Cpp
+{
+    public class UnionTests
+    {
+        [Fact]
+        private void AddCase()
+        {
+            using World world = World.Create();
+
+            Entity standing = world.Entity("Standing");
+            Entity walking = world.Entity("Walking");
+            Entity movement = world.Entity().Add(Ecs.Union);
+
+            Entity e = world.Entity()
+                .Add(movement, standing);
+            Assert.True(e.Has(movement, standing));
+
+            Table table = e.Table();
+
+            e.Add(movement, walking);
+            Assert.True(e.Table() == table);
+
+            Assert.True(e.Has(movement, walking));
+            Assert.True(!e.Has(movement, standing));
+        }
+
+        [Fact]
+        private void GetCase()
+        {
+            using World world = World.Create();
+
+            Entity standing = world.Entity("Standing");
+            world.Entity("Walking");
+            Entity movement = world.Entity().Add(Ecs.Union);
+
+            Entity e = world.Entity()
+                .Add(movement, standing);
+            Assert.True(e.Has(movement, standing));
+
+            Assert.True(e.Target(movement) == standing);
+        }
+
+        [Fact]
+        private void AddCaseWithType()
+        {
+            using World world = World.Create();
+
+            world.Component<Movement>().Entity.Add(Ecs.Union);
+
+            Entity e = world.Entity().Add<Movement, Standing>();
+            Assert.True((e.Has<Movement, Standing>()));
+
+            e.Add<Movement, Walking>();
+
+            Assert.True((e.Has<Movement, Walking>()));
+            Assert.True((!e.Has<Movement, Standing>()));
+        }
+
+        [Fact]
+        private void AddSwitchWithType()
+        {
+            using World world = World.Create();
+
+            world.Component<Movement>().Entity.Add(Ecs.Union);
+
+            Entity e = world.Entity().Add<Movement, Standing>();
+            Assert.True((e.Has<Movement, Standing>()));
+
+            e.Add<Movement, Walking>();
+
+            Assert.True((e.Has<Movement, Walking>()));
+            Assert.True((!e.Has<Movement, Standing>()));
+        }
+
+        [Fact]
+        private void AddRemoveSwitchWithType()
+        {
+            using World world = World.Create();
+
+            world.Component<Movement>().Entity.Add(Ecs.Union);
+
+            Entity e = world.Entity().Add<Movement, Standing>();
+            Assert.True(e.Has<Movement>(Ecs.Wildcard));
+            Assert.True((e.Has<Movement, Standing>()));
+
+            Table table = e.Table();
+
+            e.Add<Movement, Walking>();
+
+            Assert.True((e.Has<Movement, Walking>()));
+            Assert.True((!e.Has<Movement, Standing>()));
+            Assert.True(e.Table() == table);
+
+            Entity c = e.Target<Movement>();
+            Assert.True(c != 0);
+            Assert.True(c == world.Id<Walking>());
+
+            e.Remove<Movement>(Ecs.Wildcard);
+            Assert.True(!e.Has<Movement>(Ecs.Wildcard));
+            Assert.True((!e.Has<Movement, Walking>()));
+            Assert.True(e.Table() != table);
+        }
+
+        [Fact]
+        private void SwitchEnumType()
+        {
+            using World world = World.Create();
+
+            world.Component<Color>().Entity.Add(Ecs.Union);
+
+            Entity e = world.Entity().Add(Color.Red);
+            Assert.True(e.Has(Color.Red));
+            Assert.True(!e.Has(Color.Green));
+            Assert.True(!e.Has(Color.Blue));
+            Assert.True(e.Has<Color>(Ecs.Wildcard));
+
+            Table table = e.Table();
+
+            e.Add(Color.Green);
+            Assert.True(!e.Has(Color.Red));
+            Assert.True(e.Has(Color.Green));
+            Assert.True(!e.Has(Color.Blue));
+            Assert.True(e.Has<Color>(Ecs.Wildcard));
+            Assert.True(e.Table() == table);
+
+            e.Add(Color.Blue);
+            Assert.True(!e.Has(Color.Red));
+            Assert.True(!e.Has(Color.Green));
+            Assert.True(e.Has(Color.Blue));
+            Assert.True(e.Has<Color>(Ecs.Wildcard));
+            Assert.True(e.Table() == table);
+
+            e.Remove<Color>();
+            Assert.True(!e.Has(Color.Red));
+            Assert.True(!e.Has(Color.Green));
+            Assert.True(!e.Has(Color.Blue));
+            Assert.True(!e.Has<Color>(Ecs.Wildcard));
+            Assert.True(e.Table() != table);
+        }
+    }
+}

--- a/src/Flecs.NET/Core/Entity.cs
+++ b/src/Flecs.NET/Core/Entity.cs
@@ -3692,8 +3692,8 @@ namespace Flecs.NET.Core
         private ref Entity ObserveInternal<T>(ulong eventId, T callback, IntPtr bindingContextCallback)
             where T : Delegate
         {
-            BindingContext.RunIterContext* observerContext = Memory.AllocZeroed<BindingContext.RunIterContext>(1);
-            BindingContext.SetCallback(ref observerContext->Iterator, callback, false);
+            BindingContext.IteratorContext* observerContext = Memory.AllocZeroed<BindingContext.IteratorContext>(1);
+            BindingContext.SetCallback(ref observerContext->Callback, callback, false);
 
             ecs_observer_desc_t desc = default;
             desc.events[0] = eventId;
@@ -3701,7 +3701,7 @@ namespace Flecs.NET.Core
             desc.query.terms[0].src.id = Id;
             desc.callback = bindingContextCallback;
             desc.callback_ctx = observerContext;
-            desc.callback_ctx_free = BindingContext.RunIterContextFreePointer;
+            desc.callback_ctx_free = BindingContext.IteratorContextFreePointer;
 
             ulong observer = ecs_observer_init(World, &desc);
             ecs_add_id(World, observer, Macros.Pair(EcsChildOf, Id));

--- a/src/Flecs.NET/Core/IIterable.cs
+++ b/src/Flecs.NET/Core/IIterable.cs
@@ -1,0 +1,121 @@
+using static Flecs.NET.Bindings.Native;
+
+namespace Flecs.NET.Core
+{
+    /// <summary>
+    ///     Interface for iterable structs.
+    /// </summary>
+    public unsafe interface IIterable
+    {
+        /// <summary>
+        ///     Create an iterator object that can be modified before iterating.
+        /// </summary>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable Iter(World world = default);
+
+        /// <summary>
+        ///     Create an iterator object that can be modified before iterating.
+        /// </summary>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable Iter(Iter it);
+
+        /// <summary>
+        ///     Create an iterator object that can be modified before iterating.
+        /// </summary>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable Iter(Entity entity);
+
+        /// <summary>
+        ///     Return number of entities matched by iterable.
+        /// </summary>
+        /// <returns>The result.</returns>
+        public int Count();
+
+        /// <summary>
+        ///     Return whether iterable has any matches.
+        /// </summary>
+        /// <returns>The result.</returns>
+        public bool IsTrue();
+
+        /// <summary>
+        ///     Return first entity matched by iterable.
+        /// </summary>
+        /// <returns>The result.</returns>
+        public Entity First();
+
+        /// <summary>
+        ///     Set value for iterator variable.
+        /// </summary>
+        /// <param name="varId">The variable id.</param>
+        /// <param name="value">The entity variable value.</param>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable SetVar(int varId, ulong value);
+
+        /// <summary>
+        ///     Set value for iterator variable.
+        /// </summary>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The entity variable value.</param>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable SetVar(string name, ulong value);
+
+        /// <summary>
+        ///     Set value for iterator variable.
+        /// </summary>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The table variable value.</param>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable SetVar(string name, ecs_table_t* value);
+
+        /// <summary>
+        ///     Set value for iterator variable.
+        /// </summary>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The table variable value.</param>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable SetVar(string name, ecs_table_range_t value);
+
+        /// <summary>
+        ///     Set value for iterator variable.
+        /// </summary>
+        /// <param name="name">The variable name.</param>
+        /// <param name="value">The table variable value.</param>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable SetVar(string name, Table value);
+
+        /// <summary>
+        ///     Limit results to tables with specified group id (grouped queries only)
+        /// </summary>
+        /// <param name="groupId">The group id.</param>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable SetGroup(ulong groupId);
+
+        /// <summary>
+        ///     Limit results to tables with specified group id (grouped queries only)
+        /// </summary>
+        /// <typeparam name="T">The group type.</typeparam>
+        /// <returns>An iterable iter.</returns>
+        public IterIterable SetGroup<T>();
+
+        /// <summary>
+        ///     Iterate a query.
+        /// </summary>
+        /// <returns>An iterator.</returns>
+        public ecs_iter_t GetIter(ecs_world_t* world = null);
+
+        /// <summary>
+        ///     Progress iterator.
+        /// </summary>
+        /// <param name="it">The iterator.</param>
+        /// <returns>The result.</returns>
+        public bool GetNext(ecs_iter_t* it);
+
+        /// <summary>
+        ///     Progress instanced iterator.
+        /// </summary>
+        /// <param name="it">The iterator.</param>
+        /// <returns>The result.</returns>
+        public bool GetNextInstanced(ecs_iter_t* it);
+
+    }
+}

--- a/src/Flecs.NET/Core/Invoker.cs
+++ b/src/Flecs.NET/Core/Invoker.cs
@@ -29,17 +29,14 @@ namespace Flecs.NET.Core
         /// <param name="callback"></param>
         public static void Each(ecs_iter_t* iter, Ecs.EachEntityCallback callback)
         {
+            Ecs.Assert(iter->count > 0, "No entities returned, use Iter() or Each() without the entity argument instead.");
+
             iter->flags |= EcsIterCppEach;
-
-            ecs_world_t* world = iter->world;
-            int count = iter->count;
-
-            Ecs.Assert(count > 0, "No entities returned, use Iter() instead.");
 
             Macros.TableLock(iter->world, iter->table);
 
-            for (int i = 0; i < count; i++)
-                callback(new Entity(world, iter->entities[i]));
+            for (int i = 0; i < iter->count; i++)
+                callback(new Entity(iter->world, iter->entities[i]));
 
             Macros.TableUnlock(iter->world, iter->table);
         }
@@ -53,16 +50,26 @@ namespace Flecs.NET.Core
         {
             iter->flags |= EcsIterCppEach;
 
-            int count = iter->count == 0 ? 1 : iter->count;
-
-            Iter it = new Iter(iter);
-
             Macros.TableLock(iter->world, iter->table);
 
+            int count = iter->count == 0 ? 1 : iter->count;
+
             for (int i = 0; i < count; i++)
-                callback(it, i);
+                callback(new Iter(iter), i);
 
             Macros.TableUnlock(iter->world, iter->table);
+        }
+
+        /// <summary>
+        ///     Invokes a run callback using a delegate.
+        /// </summary>
+        /// <param name="iter"></param>
+        /// <param name="callback"></param>
+        public static void Run(ecs_iter_t* iter, Ecs.IterCallback callback)
+        {
+            Iter it = new Iter(iter);
+            iter->flags &= ~EcsIterIsValid;
+            callback(it);
         }
 
         /// <summary>
@@ -119,17 +126,14 @@ namespace Flecs.NET.Core
         /// <param name="callback"></param>
         public static void Each(ecs_iter_t* iter, delegate*<Entity, void> callback)
         {
+            Ecs.Assert(iter->count > 0, "No entities returned, use Iter() or Each() without the entity argument instead.");
+
             iter->flags |= EcsIterCppEach;
 
             Macros.TableLock(iter->world, iter->table);
 
-            ecs_world_t* world = iter->world;
-            int count = iter->count;
-
-            Ecs.Assert(count > 0, "No entities returned, use Iter() instead.");
-
-            for (int i = 0; i < count; i++)
-                callback(new Entity(world, iter->entities[i]));
+            for (int i = 0; i < iter->count; i++)
+                callback(new Entity(iter->world, iter->entities[i]));
 
             Macros.TableUnlock(iter->world, iter->table);
         }
@@ -143,19 +147,26 @@ namespace Flecs.NET.Core
         {
             iter->flags |= EcsIterCppEach;
 
-            int count = iter->count;
-
-            if (count == 0)
-                count = 1;
-
-            Iter it = new Iter(iter);
-
             Macros.TableLock(iter->world, iter->table);
 
+            int count = iter->count == 0 ? 1 : iter->count;
+
             for (int i = 0; i < count; i++)
-                callback(it, i);
+                callback(new Iter(iter), i);
 
             Macros.TableUnlock(iter->world, iter->table);
+        }
+
+        /// <summary>
+        ///     Invokes a run callback using a delegate.
+        /// </summary>
+        /// <param name="iter"></param>
+        /// <param name="callback"></param>
+        public static void Run(ecs_iter_t* iter, delegate*<Iter, void> callback)
+        {
+            Iter it = new Iter(iter);
+            iter->flags &= ~EcsIterIsValid;
+            callback(it);
         }
 #endif
     }

--- a/src/Flecs.NET/Core/IterIterable.cs
+++ b/src/Flecs.NET/Core/IterIterable.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 #endif
 using System;
+using System.Runtime.CompilerServices;
 using Flecs.NET.Utilities;
 using static Flecs.NET.Bindings.Native;
 
@@ -10,17 +11,20 @@ namespace Flecs.NET.Core
     /// <summary>
     ///     An iterator object that can be modified before iterating.
     /// </summary>
-    public unsafe partial struct IterIterable : IEquatable<IterIterable>
+    public unsafe partial struct IterIterable : IIterable, IEquatable<IterIterable>
     {
         private ecs_iter_t _iter;
+        private IterableType _iterableType;
 
         /// <summary>
         ///     Creates an iter iterable.
         /// </summary>
-        /// <param name="iter"></param>
-        public IterIterable(ecs_iter_t iter)
+        /// <param name="iter">The iterator.</param>
+        /// <param name="iterableType">The iterator type.</param>
+        public IterIterable(ecs_iter_t iter, IterableType iterableType)
         {
             _iter = iter;
+            _iterableType = iterableType;
         }
 
         /// <summary>
@@ -248,39 +252,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Iter(Ecs.IterCallback callback)
         {
-            Iter(_iter.world, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Entity entity, Ecs.IterCallback callback)
-        {
-            Iter(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Iter it, Ecs.IterCallback callback)
-        {
-            Iter(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(World world, Ecs.IterCallback callback)
-        {
-            ecs_iter_t iter = _iter;
-            iter.world = world;
-            while (ecs_query_next(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNext(&iter))
                 Invoker.Iter(&iter, callback);
         }
 
@@ -290,39 +263,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(Ecs.EachEntityCallback callback)
         {
-            Each(_iter.world, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, Ecs.EachEntityCallback callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, Ecs.EachEntityCallback callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, Ecs.EachEntityCallback callback)
-        {
-            ecs_iter_t iter = _iter;
-            iter.world = world;
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
         }
 
@@ -332,40 +274,19 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(Ecs.EachIndexCallback callback)
         {
-            Each(_iter.world, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, Ecs.EachIndexCallback callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, Ecs.EachIndexCallback callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, Ecs.EachIndexCallback callback)
-        {
-            ecs_iter_t iter = _iter;
-            iter.world = world;
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
+        }
+
+        /// <summary>
+        ///     Iterates the query using the provided callback.
+        /// </summary>
+        /// <param name="callback">The callback.</param>
+        public void Run(Ecs.IterCallback callback)
+        {
+            ecs_iter_t iter = GetIter();
+            Invoker.Run(&iter, callback);
         }
 
 #if NET5_0_OR_GREATER
@@ -375,39 +296,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Iter(delegate*<Iter, void> callback)
         {
-            Iter(_iter.world, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Entity entity, delegate*<Iter, void> callback)
-        {
-            Iter(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Iter it, delegate*<Iter, void> callback)
-        {
-            Iter(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(World world, delegate*<Iter, void> callback)
-        {
-            ecs_iter_t iter = _iter;
-            iter.world = world;
-            while (ecs_query_next(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNext(&iter))
                 Invoker.Iter(&iter, callback);
         }
 
@@ -417,39 +307,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(delegate*<Entity, void> callback)
         {
-            Each(_iter.world, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, delegate*<Entity, void> callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, delegate*<Entity, void> callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, delegate*<Entity, void> callback)
-        {
-            ecs_iter_t iter = _iter;
-            iter.world = world;
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
         }
 
@@ -459,40 +318,19 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(delegate*<Iter, int, void> callback)
         {
-            Each(_iter.world, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, delegate*<Iter, int, void> callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, delegate*<Iter, int, void> callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, delegate*<Iter, int, void>callback)
-        {
-            ecs_iter_t iter = _iter;
-            iter.world = world;
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
+        }
+
+        /// <summary>
+        ///     Iterates the query using the provided callback.
+        /// </summary>
+        /// <param name="callback">The callback.</param>
+        public void Run(delegate*<Iter, void> callback)
+        {
+            ecs_iter_t iter = GetIter();
+            Invoker.Run(&iter, callback);
         }
 #endif
 
@@ -545,6 +383,126 @@ namespace Flecs.NET.Core
         public static bool operator !=(IterIterable left, IterIterable right)
         {
             return !(left == right);
+        }
+    }
+
+    // IIterable Interface
+    public unsafe partial struct IterIterable
+    {
+        /// <inheritdoc cref="IIterable.GetIter"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ecs_iter_t GetIter(ecs_world_t* world = null)
+        {
+            if (world == null)
+                return _iter;
+
+            ecs_iter_t result = _iter;
+            result.world = world;
+            return result;
+        }
+
+        /// <inheritdoc cref="IIterable.GetNext"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool GetNext(ecs_iter_t* it)
+        {
+            return _iterableType switch
+            {
+                IterableType.Query => Macros.Bool(ecs_query_next(it)),
+                IterableType.Worker => Macros.Bool(ecs_worker_next(it)),
+                IterableType.Page => Macros.Bool(ecs_page_next(it)),
+                _ => throw new Ecs.ErrorException()
+            };
+        }
+
+        /// <inheritdoc cref="IIterable.GetNextInstanced"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool GetNextInstanced(ecs_iter_t* it)
+        {
+            return _iterableType switch
+            {
+                IterableType.Query => Macros.Bool(ecs_query_next_instanced(it)),
+                IterableType.Worker => Macros.Bool(ecs_worker_next(it)),
+                IterableType.Page => Macros.Bool(ecs_page_next(it)),
+                _ => throw new Ecs.ErrorException()
+            };
+        }
+
+        /// <inheritdoc cref="IIterable.Iter(Flecs.NET.Core.World)"/>
+        public IterIterable Iter(World world = default)
+        {
+            return new IterIterable(GetIter(world), _iterableType);
+        }
+
+        /// <inheritdoc cref="IIterable.Iter(Flecs.NET.Core.Iter)"/>
+        public IterIterable Iter(Iter it)
+        {
+            return Iter(it.World());
+        }
+
+        /// <inheritdoc cref="IIterable.Iter(Flecs.NET.Core.Entity)"/>
+        public IterIterable Iter(Entity entity)
+        {
+            return Iter(entity.CsWorld());
+        }
+
+        /// <inheritdoc cref="IIterable.Count()"/>
+        int IIterable.Count()
+        {
+            return Iter().Count();
+        }
+
+        /// <inheritdoc cref="IIterable.IsTrue()"/>
+        bool IIterable.IsTrue()
+        {
+            return Iter().IsTrue();
+        }
+
+        /// <inheritdoc cref="IIterable.First()"/>
+        Entity IIterable.First()
+        {
+            return Iter().First();
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(int, ulong)"/>
+        IterIterable IIterable.SetVar(int varId, ulong value)
+        {
+            return Iter().SetVar(varId, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, ulong)"/>
+        IterIterable IIterable.SetVar(string name, ulong value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, ecs_table_t*)"/>
+        IterIterable IIterable.SetVar(string name, ecs_table_t* value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, ecs_table_range_t)"/>
+        IterIterable IIterable.SetVar(string name, ecs_table_range_t value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, Table)"/>
+        IterIterable IIterable.SetVar(string name, Table value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetGroup(ulong)"/>
+        IterIterable IIterable.SetGroup(ulong groupId)
+        {
+            return Iter().SetGroup(groupId);
+        }
+
+        /// <inheritdoc cref="IIterable.SetGroup{T}()"/>
+        IterIterable IIterable.SetGroup<T>()
+        {
+            return Iter().SetGroup<T>();
         }
     }
 }

--- a/src/Flecs.NET/Core/IterableType.cs
+++ b/src/Flecs.NET/Core/IterableType.cs
@@ -1,0 +1,21 @@
+namespace Flecs.NET.Core
+{
+    /// <summary>
+    ///     Represents an iterable type.
+    /// </summary>
+    public enum IterableType
+    {
+        /// <summary>
+        ///     Query iterable.
+        /// </summary>
+        Query,
+        /// <summary>
+        ///     Worker iterable.
+        /// </summary>
+        Worker,
+        /// <summary>
+        ///     Page iterable.
+        /// </summary>
+        Page
+    }
+}

--- a/src/Flecs.NET/Core/Query.cs
+++ b/src/Flecs.NET/Core/Query.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Flecs.NET.Utilities;
 using static Flecs.NET.Bindings.Native;
@@ -8,7 +9,7 @@ namespace Flecs.NET.Core
     /// <summary>
     ///     A wrapper around ecs_query_t.
     /// </summary>
-    public unsafe partial struct Query : IEquatable<Query>, IDisposable
+    public unsafe partial struct Query : IIterable, IEquatable<Query>, IDisposable
     {
         private ecs_world_t* _world;
         private ecs_query_t* _handle;
@@ -213,38 +214,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Iter(Ecs.IterCallback callback)
         {
-            Iter(World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Entity entity, Ecs.IterCallback callback)
-        {
-            Iter(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Iter it, Ecs.IterCallback callback)
-        {
-            Iter(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(World world, Ecs.IterCallback callback)
-        {
-            ecs_iter_t iter = ecs_query_iter(world, Handle);
-            while (ecs_query_next(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNext(&iter))
                 Invoker.Iter(&iter, callback);
         }
 
@@ -254,38 +225,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(Ecs.EachEntityCallback callback)
         {
-            Each(World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, Ecs.EachEntityCallback callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, Ecs.EachEntityCallback callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, Ecs.EachEntityCallback callback)
-        {
-            ecs_iter_t iter = ecs_query_iter(world, Handle);
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
         }
 
@@ -295,39 +236,19 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(Ecs.EachIndexCallback callback)
         {
-            Each(World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, Ecs.EachIndexCallback callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, Ecs.EachIndexCallback callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, Ecs.EachIndexCallback callback)
-        {
-            ecs_iter_t iter = ecs_query_iter(world, Handle);
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
+        }
+
+        /// <summary>
+        ///     Iterates the query using the provided callback.
+        /// </summary>
+        /// <param name="callback">The callback.</param>
+        public void Run(Ecs.IterCallback callback)
+        {
+            ecs_iter_t iter = GetIter();
+            Invoker.Run(&iter, callback);
         }
 
 #if NET5_0_OR_GREATER
@@ -337,38 +258,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Iter(delegate*<Iter, void> callback)
         {
-            Iter(World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Entity entity, delegate*<Iter, void> callback)
-        {
-            Iter(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(Iter it, delegate*<Iter, void> callback)
-        {
-            Iter(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Iter(World world, delegate*<Iter, void> callback)
-        {
-            ecs_iter_t iter = ecs_query_iter(world, Handle);
-            while (ecs_query_next(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNext(&iter))
                 Invoker.Iter(&iter, callback);
         }
 
@@ -378,38 +269,8 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(delegate*<Entity, void> callback)
         {
-            Each(World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, delegate*<Entity, void> callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, delegate*<Entity, void> callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, delegate*<Entity, void> callback)
-        {
-            ecs_iter_t iter = ecs_query_iter(world, Handle);
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
         }
 
@@ -419,152 +280,21 @@ namespace Flecs.NET.Core
         /// <param name="callback">The callback.</param>
         public void Each(delegate*<Iter, int, void> callback)
         {
-            Each(World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="entity">The entity.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Entity entity, delegate*<Iter, int, void> callback)
-        {
-            Each(entity.World, callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="it">The iter.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(Iter it, delegate*<Iter, int, void> callback)
-        {
-            Each(it.World(), callback);
-        }
-
-        /// <summary>
-        ///     Iterates the query using the provided callback.
-        /// </summary>
-        /// <param name="world">The world.</param>
-        /// <param name="callback">The callback.</param>
-        public void Each(World world, delegate*<Iter, int, void>callback)
-        {
-            ecs_iter_t iter = ecs_query_iter(world, Handle);
-            while (ecs_query_next_instanced(&iter) == 1)
+            ecs_iter_t iter = GetIter();
+            while (GetNextInstanced(&iter))
                 Invoker.Each(&iter, callback);
         }
+
+        /// <summary>
+        ///     Iterates the query using the provided callback.
+        /// </summary>
+        /// <param name="callback">The callback.</param>
+        public void Run(delegate*<Iter, void> callback)
+        {
+            ecs_iter_t iter = GetIter();
+            Invoker.Run(&iter, callback);
+        }
 #endif
-
-        /// <summary>
-        ///     Create an iterator object that can be modified before iterating.
-        /// </summary>
-        /// <returns></returns>
-        public IterIterable Iter()
-        {
-            return new IterIterable(ecs_query_iter(World, Handle));
-        }
-
-        /// <summary>
-        ///     Return number of entities matched by iterable.
-        /// </summary>
-        /// <returns></returns>
-        public int Count()
-        {
-            return Iter().Count();
-        }
-
-        /// <summary>
-        ///     Return whether iterable has any matches.
-        /// </summary>
-        /// <returns></returns>
-        public bool IsTrue()
-        {
-            return Iter().IsTrue();
-        }
-
-        /// <summary>
-        ///     Return first entity matched by iterable.
-        /// </summary>
-        /// <returns></returns>
-        public Entity First()
-        {
-            return Iter().First();
-        }
-
-        /// <summary>
-        ///     Set value for iterator variable.
-        /// </summary>
-        /// <param name="varId">The variable id.</param>
-        /// <param name="value">The entity variable value.</param>
-        /// <returns>Iterable iter struct.</returns>
-        public IterIterable SetVar(int varId, ulong value)
-        {
-            return Iter().SetVar(varId, value);
-        }
-
-        /// <summary>
-        ///     Set value for iterator variable.
-        /// </summary>
-        /// <param name="name">The variable name.</param>
-        /// <param name="value">The entity variable value.</param>
-        /// <returns>Iterable iter struct.</returns>
-        public IterIterable SetVar(string name, ulong value)
-        {
-            return Iter().SetVar(name, value);
-        }
-
-        /// <summary>
-        ///     Set value for iterator variable.
-        /// </summary>
-        /// <param name="name">The variable name.</param>
-        /// <param name="value">The table variable value.</param>
-        /// <returns>Iterable iter struct.</returns>
-        public IterIterable SetVar(string name, ecs_table_t *value)
-        {
-            return Iter().SetVar(name, value);
-        }
-
-        /// <summary>
-        ///     Set value for iterator variable.
-        /// </summary>
-        /// <param name="name">The variable name.</param>
-        /// <param name="value">The table variable value.</param>
-        /// <returns>Iterable iter struct.</returns>
-        public IterIterable SetVar(string name, ecs_table_range_t value)
-        {
-            return Iter().SetVar(name, value);
-        }
-
-        /// <summary>
-        ///     Set value for iterator variable.
-        /// </summary>
-        /// <param name="name">The variable name.</param>
-        /// <param name="value">The table variable value.</param>
-        /// <returns>Iterable iter struct.</returns>
-        public IterIterable SetVar(string name, Table value)
-        {
-            return Iter().SetVar(name, value);
-        }
-
-        /// <summary>
-        ///     Limit results to tables with specified group id (grouped queries only)
-        /// </summary>
-        /// <param name="groupId">The group id.</param>
-        /// <returns>Iterable iter struct.</returns>
-        public IterIterable SetGroup(ulong groupId)
-        {
-            return Iter().SetGroup(groupId);
-        }
-
-        /// <summary>
-        ///     Limit results to tables with specified group id (grouped queries only)
-        /// </summary>
-        /// <typeparam name="T">The group type.</typeparam>
-        /// <returns>Iterable iter struct.</returns>
-        public IterIterable SetGroup<T>()
-        {
-            return Iter().SetGroup<T>();
-        }
 
         /// <summary>
         ///     Converts a <see cref="Query"/> instance to an <see cref="ecs_query_t"/>*.
@@ -655,6 +385,112 @@ namespace Flecs.NET.Core
         public static bool operator !=(Query left, Query right)
         {
             return !(left == right);
+        }
+    }
+
+    // IIterable Interface
+    public unsafe partial struct Query
+    {
+        /// <inheritdoc cref="IIterable.GetIter"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ecs_iter_t GetIter(ecs_world_t* world = null)
+        {
+            if (world == null)
+                world = Handle->world;
+
+            return ecs_query_iter(world, Handle);
+        }
+
+        /// <inheritdoc cref="IIterable.GetNext"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool GetNext(ecs_iter_t* it)
+        {
+            return Macros.Bool(ecs_query_next(it));
+        }
+
+        /// <inheritdoc cref="IIterable.GetNextInstanced"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool GetNextInstanced(ecs_iter_t* it)
+        {
+            return Macros.Bool(ecs_query_next_instanced(it));
+        }
+
+        /// <inheritdoc cref="IIterable.Iter(Flecs.NET.Core.World)"/>
+        public IterIterable Iter(World world = default)
+        {
+            return new IterIterable(GetIter(world), IterableType.Query);
+        }
+
+        /// <inheritdoc cref="IIterable.Iter(Flecs.NET.Core.Iter)"/>
+        public IterIterable Iter(Iter it)
+        {
+            return Iter(it.World());
+        }
+
+        /// <inheritdoc cref="IIterable.Iter(Flecs.NET.Core.Entity)"/>
+        public IterIterable Iter(Entity entity)
+        {
+            return Iter(entity.CsWorld());
+        }
+
+        /// <inheritdoc cref="IIterable.Count()"/>
+        public int Count()
+        {
+            return Iter().Count();
+        }
+
+        /// <inheritdoc cref="IIterable.IsTrue()"/>
+        public bool IsTrue()
+        {
+            return Iter().IsTrue();
+        }
+
+        /// <inheritdoc cref="IIterable.First()"/>
+        public Entity First()
+        {
+            return Iter().First();
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(int, ulong)"/>
+        public IterIterable SetVar(int varId, ulong value)
+        {
+            return Iter().SetVar(varId, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, ulong)"/>
+        public IterIterable SetVar(string name, ulong value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, ecs_table_t*)"/>
+        public IterIterable SetVar(string name, ecs_table_t* value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, ecs_table_range_t)"/>
+        public IterIterable SetVar(string name, ecs_table_range_t value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetVar(string, Table)"/>
+        public IterIterable SetVar(string name, Table value)
+        {
+            return Iter().SetVar(name, value);
+        }
+
+        /// <inheritdoc cref="IIterable.SetGroup(ulong)"/>
+        public IterIterable SetGroup(ulong groupId)
+        {
+            return Iter().SetGroup(groupId);
+        }
+
+        /// <inheritdoc cref="IIterable.SetGroup{T}()"/>
+        public IterIterable SetGroup<T>()
+        {
+            return Iter().SetGroup<T>();
         }
     }
 }

--- a/src/Flecs.NET/Core/Table.cs
+++ b/src/Flecs.NET/Core/Table.cs
@@ -42,6 +42,18 @@ namespace Flecs.NET.Core
         }
 
         /// <summary>
+        ///     Creates a table from the provided handle.
+        /// </summary>
+        /// <param name="table"></param>
+        public Table(ecs_table_t* table)
+        {
+            World = null;
+            Handle = table;
+            Offset = 0;
+            Count = 0;
+        }
+
+        /// <summary>
         ///     Creates a table from the provided world and handle.
         /// </summary>
         /// <param name="world"></param>
@@ -656,9 +668,19 @@ namespace Flecs.NET.Core
         /// </summary>
         /// <param name="table"></param>
         /// <returns></returns>
-        public static implicit operator ecs_table_t*(Table table)
+        public static ecs_table_t* To(Table table)
         {
-            return To(table);
+            return table.Handle;
+        }
+
+        /// <summary>
+        ///     Converts a <see cref="ecs_table_t"/>* instance to a <see cref="Table"/>.
+        /// </summary>
+        /// <param name="table"></param>
+        /// <returns></returns>
+        public static Table From(ecs_table_t* table)
+        {
+            return new Table(table);
         }
 
         /// <summary>
@@ -666,9 +688,19 @@ namespace Flecs.NET.Core
         /// </summary>
         /// <param name="table"></param>
         /// <returns></returns>
-        public static ecs_table_t* To(Table table)
+        public static implicit operator ecs_table_t*(Table table)
         {
-            return table.Handle;
+            return To(table);
+        }
+
+        /// <summary>
+        ///     Converts a <see cref="ecs_table_t"/>* instance to a <see cref="Table"/>.
+        /// </summary>
+        /// <param name="table"></param>
+        /// <returns></returns>
+        public static implicit operator Table(ecs_table_t* table)
+        {
+            return From(table);
         }
 
         /// <summary>


### PR DESCRIPTION
Adds new run callback API and update tests + examples

```c#
// Run
world.Routine()
    .Run((Iter it) =>
    {
        while (it.Next())
        {
            Field<Position> p = it.Field<Position>(0);
            Field<Velocity> v = it.Field<Velocity>(1);

            foreach (int i in it)
            {
                p[i].X += v[i].X;
                p[i].Y += v[i].Y;
            }
        }
    });

// Run + Iter
world.Routine()
    .Run(
        (Iter it) =>
        {
            while (it.Next())
                it.Callback(); // Same as it.Each()
        },
        (Iter it, Field<Position> p, Field<Velocity> v) =>
        {
            foreach (int i in it)
            {
                p[i].X += v[i].X;
                p[i].Y += v[i].Y;
            }
        }
    );

// Run + Each
world.Routine()
    .Run(
        (Iter it) =>
        {
            while (it.Next())
                it.Each(); // Same as it.Callback()
        },
        (ref Position p, ref Velocity v) =>
        {
            p.X += v.X;
            p.Y += v.Y;
        }
    );
```