### PR TITLE
Fixed class name in Unity initialization in Editor

### DIFF
--- a/src/Flecs.NET.Unity/FlecsInitialization.cs
+++ b/src/Flecs.NET.Unity/FlecsInitialization.cs
@@ -20,7 +20,7 @@ namespace Flecs.NET.Unity
         public static void Initialize()
         {
 #if UNITY_EDITOR
-            Native.BindgenInternal.DllFilePaths.InsertRange(0, EditorPackagePaths());
+            flecs.BindgenInternal.DllFilePaths.InsertRange(0, EditorPackagePaths());
 #else
             flecs.BindgenInternal.DllFilePaths.InsertRange(0, RuntimePackagePaths());
 #endif


### PR DESCRIPTION
Fixes wrong class name which causes compilation error.