### PR TITLE
Update zig build script and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,11 @@ jobs:
       shell: bash
       run: |
         if [ '${{ github.event.inputs.nuget-registry }}' == 'NuGet' ]; then
-          dotnet pack --no-build --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Debug
-          dotnet pack --no-build --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Release
+          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Debug
+          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Release
         else
-          dotnet pack --no-build --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:DebugType=embedded -c Debug
-          dotnet pack --no-build --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:DebugType=embedded -c Release
+          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:DebugType=embedded -c Debug
+          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:DebugType=embedded -c Release
         fi
 
     - name: Upload Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,8 @@ jobs:
           dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Debug
           dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Release
         else
-          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:DebugType=embedded -c Debug
-          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:DebugType=embedded -c Release
+          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -c Debug
+          dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -c Release
         fi
 
     - name: Upload Artifacts

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,7 @@
         <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(ContinuousIntegrationBuild)' == ''">true</ContinuousIntegrationBuild>
         <Deterministic Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(Deterministic)' == ''">true</Deterministic>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder Condition="'$(FlecsPackPdb)' == 'true'">$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -134,25 +134,25 @@
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir linux-x64        --prefix-exe-dir linux-x64        -Dtarget=x86_64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir win-x64          --prefix-exe-dir win-x64          -Dtarget=x86_64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir osx-x64          --prefix-exe-dir osx-x64          -Dtarget=x86_64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir linux-x64        --prefix-exe-dir linux-x64        -Dtarget=x86_64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir win-x64          --prefix-exe-dir win-x64          -Dtarget=x86_64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir osx-x64          --prefix-exe-dir osx-x64          -Dtarget=x86_64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <!--Arm64-->
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir linux-arm64        --prefix-exe-dir linux-arm64        -Dtarget=aarch64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir win-arm64          --prefix-exe-dir win-arm64          -Dtarget=aarch64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir osx-arm64          --prefix-exe-dir osx-arm64          -Dtarget=aarch64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --sysroot $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --search-prefix $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir linux-arm64        --prefix-exe-dir linux-arm64        -Dtarget=aarch64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir win-arm64          --prefix-exe-dir win-arm64          -Dtarget=aarch64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir osx-arm64          --prefix-exe-dir osx-arm64          -Dtarget=aarch64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --sysroot $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --search-prefix $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
     </Target>
 
     <ItemGroup>

--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -134,25 +134,25 @@
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir linux-x64        --prefix-exe-dir linux-x64        -Dtarget=x86_64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir win-x64          --prefix-exe-dir win-x64          -Dtarget=x86_64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir osx-x64          --prefix-exe-dir osx-x64          -Dtarget=x86_64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir linux-x64        --prefix-exe-dir linux-x64        -Dtarget=x86_64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir win-x64          --prefix-exe-dir win-x64          -Dtarget=x86_64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir osx-x64          --prefix-exe-dir osx-x64          -Dtarget=x86_64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <!--Arm64-->
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir linux-arm64        --prefix-exe-dir linux-arm64        -Dtarget=aarch64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir win-arm64          --prefix-exe-dir win-arm64          -Dtarget=aarch64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir osx-arm64          --prefix-exe-dir osx-arm64          -Dtarget=aarch64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --search-prefix $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --sysroot $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir linux-arm64        --prefix-exe-dir linux-arm64        -Dtarget=aarch64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir win-arm64          --prefix-exe-dir win-arm64          -Dtarget=aarch64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir osx-arm64          --prefix-exe-dir osx-arm64          -Dtarget=aarch64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --search-prefix $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --search-prefix $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --sysroot $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
     </Target>
 
     <ItemGroup>

--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -134,25 +134,25 @@
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir linux-x64        --prefix-exe-dir linux-x64        -Dtarget=x86_64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir win-x64          --prefix-exe-dir win-x64          -Dtarget=x86_64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir osx-x64          --prefix-exe-dir osx-x64          -Dtarget=x86_64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator -Dios-simulator-sdk-path=$(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir linux-x64        --prefix-exe-dir linux-x64        -Dtarget=x86_64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir win-x64          --prefix-exe-dir win-x64          -Dtarget=x86_64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir osx-x64          --prefix-exe-dir osx-x64          -Dtarget=x86_64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator -Dios-simulator-sdk-path=$(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-x64 --prefix-exe-dir iossimulator-x64 -Dtarget=x86_64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <!--Arm64-->
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir linux-arm64        --prefix-exe-dir linux-arm64        -Dtarget=aarch64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir win-arm64          --prefix-exe-dir win-arm64          -Dtarget=aarch64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir osx-arm64          --prefix-exe-dir osx-arm64          -Dtarget=aarch64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           -Dios-sdk-path=$(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator -Dios-simulator-sdk-path=$(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --sysroot $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=Debug --prefix debug --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
 
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir linux-arm64        --prefix-exe-dir linux-arm64        -Dtarget=aarch64-linux-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir win-arm64          --prefix-exe-dir win-arm64          -Dtarget=aarch64-windows-gnu"/>
         <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir osx-arm64          --prefix-exe-dir osx-arm64          -Dtarget=aarch64-macos"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           -Dios-sdk-path=$(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
-        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator -Dios-simulator-sdk-path=$(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir ios-arm64          --prefix-exe-dir ios-arm64          -Dtarget=aarch64-ios           --sysroot $(IosSdkPath)" Condition="'$(IosSdkPath)' != ''"/>
+        <Exec Command="$(ZigExePath) build $(FlecsCompileOptions) -Doptimize=ReleaseFast --prefix release --prefix-lib-dir iossimulator-arm64 --prefix-exe-dir iossimulator-arm64 -Dtarget=aarch64-ios-simulator --sysroot $(IosSimulatorSdkPath)" Condition="'$(IosSimulatorSdkPath)' != ''"/>
     </Target>
 
     <ItemGroup>

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -34,6 +34,9 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
         .windows => {
             lib.linkSystemLibrary("ws2_32");
         },
+        .ios => {
+            lib.addIncludePath(.{ .cwd_relative = "/usr/include" });
+        },
         else => {},
     }
 
@@ -45,6 +48,8 @@ pub fn build(b: *Build) void {
         .optimize = b.standardOptimizeOption(.{}),
         .target = b.standardTargetOptions(.{}),
         .soft_assert = b.option(bool, "soft-assert", "Compile with the FLECS_SOFT_ASSERT define.") orelse false,
+        .ios_sdk_path = b.option([]const u8, "ios-sdk-path", "Path to an IOS SDK."),
+        .ios_simulator_sdk_path = b.option([]const u8, "ios-simulator-sdk-path", "Path to an IOS simulator SDK."),
     };
 
     compileFlecs(options, b, LibType.Shared);

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -19,14 +19,9 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
         }),
     };
 
-    lib.addCSourceFile(.{ .file = b.path("../../submodules/flecs/flecs.c"), .flags = &.{} });
     lib.linkLibC();
-
-    if (options.optimize == .Debug) {
-        lib.defineCMacro("FLECS_DEBUG", null);
-    } else {
-        lib.defineCMacro("FLECS_NDEBUG", null);
-    }
+    lib.addCSourceFile(.{ .file = b.path("../../submodules/flecs/flecs.c"), .flags = &.{} });
+    lib.defineCMacro(if (options.optimize == .Debug) "FLECS_DEBUG" else "FLECS_NDEBUG", null);
 
     if (options.soft_assert) {
         lib.defineCMacro("FLECS_SOFT_ASSERT", null);

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -34,17 +34,6 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
         .windows => {
             lib.linkSystemLibrary("ws2_32");
         },
-        .ios => {
-            lib.addIncludePath(.{ .cwd_relative = "/usr/include" });
-
-            if (options.target.result.abi == .simulator and options.ios_simulator_sdk_path != null) {
-                b.sysroot = options.ios_simulator_sdk_path;
-            } else if (options.ios_sdk_path != null) {
-                b.sysroot = options.ios_sdk_path;
-            } else {
-                @panic("A path to an IOS SDK needs to be provided when compiling for IOS.");
-            }
-        },
         else => {},
     }
 
@@ -56,8 +45,6 @@ pub fn build(b: *Build) void {
         .optimize = b.standardOptimizeOption(.{}),
         .target = b.standardTargetOptions(.{}),
         .soft_assert = b.option(bool, "soft-assert", "Compile with the FLECS_SOFT_ASSERT define.") orelse false,
-        .ios_sdk_path = b.option([]const u8, "ios-sdk-path", "Path to an IOS SDK."),
-        .ios_simulator_sdk_path = b.option([]const u8, "ios-simulator-sdk-path", "Path to an IOS simulator SDK."),
     };
 
     compileFlecs(options, b, LibType.Shared);

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -35,7 +35,7 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
             lib.linkSystemLibrary("ws2_32");
         },
         .ios => {
-            lib.addSystemIncludePath(.{ .cwd_relative = "/usr/include" });
+            lib.addIncludePath(.{ .cwd_relative = "/usr/include" });
 
             if (options.target.result.abi == .simulator and options.ios_simulator_sdk_path != null) {
                 b.sysroot = options.ios_simulator_sdk_path;

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -35,7 +35,13 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
             lib.linkSystemLibrary("ws2_32");
         },
         .ios => {
+            if (b.sysroot == null) {
+                @panic("A --sysroot path to an IOS SDK needs to be provided when compiling for IOS.");
+            }
+
+            lib.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ b.sysroot.?, "/System/Library/Frameworks" }) });
             lib.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ b.sysroot.?, "/usr/include" }) });
+            lib.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ b.sysroot.?, "/usr/lib" }) });
         },
         else => {},
     }

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -35,7 +35,7 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
             lib.linkSystemLibrary("ws2_32");
         },
         .ios => {
-            lib.addIncludePath(.{ .cwd_relative = "/usr/include" });
+            lib.addSystemIncludePath(.{ .cwd_relative = "/usr/include" });
         },
         else => {},
     }
@@ -48,8 +48,6 @@ pub fn build(b: *Build) void {
         .optimize = b.standardOptimizeOption(.{}),
         .target = b.standardTargetOptions(.{}),
         .soft_assert = b.option(bool, "soft-assert", "Compile with the FLECS_SOFT_ASSERT define.") orelse false,
-        .ios_sdk_path = b.option([]const u8, "ios-sdk-path", "Path to an IOS SDK."),
-        .ios_simulator_sdk_path = b.option([]const u8, "ios-simulator-sdk-path", "Path to an IOS simulator SDK."),
     };
 
     compileFlecs(options, b, LibType.Shared);

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -22,8 +22,10 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
     lib.addCSourceFile(.{ .file = b.path("../../submodules/flecs/flecs.c"), .flags = &.{} });
     lib.linkLibC();
 
-    if (options.optimize != .Debug) {
-        lib.defineCMacro("NDEBUG", null);
+    if (options.optimize == .Debug) {
+        lib.defineCMacro("FLECS_DEBUG", null);
+    } else {
+        lib.defineCMacro("FLECS_NDEBUG", null);
     }
 
     if (options.soft_assert) {

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -35,7 +35,7 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
             lib.linkSystemLibrary("ws2_32");
         },
         .ios => {
-            lib.addSystemIncludePath(.{ .cwd_relative = "/usr/include" });
+            lib.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ b.sysroot.?, "/usr/include" }) });
         },
         else => {},
     }

--- a/src/Flecs.NET.Native/build.zig
+++ b/src/Flecs.NET.Native/build.zig
@@ -35,7 +35,7 @@ pub fn compileFlecs(options: anytype, b: *Build, lib_type: LibType) void {
             lib.linkSystemLibrary("ws2_32");
         },
         .ios => {
-            lib.addSystemIncludePath(b.path("/usr/include"));
+            lib.addSystemIncludePath(.{ .cwd_relative = "/usr/include" });
 
             if (options.target.result.abi == .simulator and options.ios_simulator_sdk_path != null) {
                 b.sysroot = options.ios_simulator_sdk_path;


### PR DESCRIPTION
- Updated Vezel.Zig.Toolsets NuGet package to version 0.13.0.1.
- Fixed issue where CI was packaging release native libraries for debug builds
- Fixed pdbs not being packaged when pushing to gitlab feed