### PR TITLE
Fixed flecs.h directory after move to "distr" directory

### DIFF
--- a/src/Flecs.NET.Bindgen/Program.cs
+++ b/src/Flecs.NET.Bindgen/Program.cs
@@ -44,7 +44,7 @@ BindingGenerator.Generate(bindingOptions);
 
 string GetFlecsHeaderPath([CallerFilePath] string filePath = "")
 {
-    return Path.GetFullPath(Path.Combine(filePath, "..", "..", "..", "submodules", "flecs", "flecs.h"));
+    return Path.GetFullPath(Path.Combine(filePath, "..", "..", "..", "submodules", "flecs", "distr", "flecs.h"));
 }
 
 string GetBindingsOutputPath([CallerFilePath] string filePath = "")


### PR DESCRIPTION
`flecs.h` [was moved](https://github.com/SanderMertens/flecs/commit/17a6f7fc6877c7868cbb44ad38379b9b43c57fdd) from the root directory of the C project to a new directory called `distr`. The PR corrects the path for the .NET bindings