### PR TITLE
Add support for QueryBuilder#TermAt<T> and QueryBuilder#TermAt<T>(int)

### DIFF
--- a/src/Flecs.NET.Codegen/Generators/QueryBuilder.cs
+++ b/src/Flecs.NET.Codegen/Generators/QueryBuilder.cs
@@ -1031,10 +1031,24 @@ public class QueryBuilder : IIncrementalGenerator
                 return ref this;
             }
     
+            /// <inheritdoc cref="Core.QueryBuilder.TermAt{T}()"/>
+            public ref {{Generator.GetTypeName(type, i)}} TermAt<T>()
+            {
+                Ecs.GetQueryBuilder(ref this).TermAt<T>();
+                return ref this;
+            }
+
             /// <inheritdoc cref="Core.QueryBuilder.TermAt(int)"/>
             public ref {{Generator.GetTypeName(type, i)}} TermAt(int termIndex)
             {
                 Ecs.GetQueryBuilder(ref this).TermAt(termIndex);
+                return ref this;
+            }
+
+            /// <inheritdoc cref="Core.QueryBuilder.TermAt{T}(int)"/>
+            public ref {{Generator.GetTypeName(type, i)}} TermAt<T>(int termIndex)
+            {
+                Ecs.GetQueryBuilder(ref this).TermAt<T>(termIndex);
                 return ref this;
             }
     

--- a/src/Flecs.NET.Tests/CSharp/Core/QueryBuilderTests.cs
+++ b/src/Flecs.NET.Tests/CSharp/Core/QueryBuilderTests.cs
@@ -81,4 +81,57 @@ public class QueryBuilderTests
             return ~GroupByFirstId(world, table, id);
         }
     }
+
+
+    [Fact]
+    private void TermAt()
+    {
+        using World world = World.Create();
+        world.Component<Tag>();
+        world.Component<Position>();
+        world.Component<Velocity>();
+
+        world.QueryBuilder()
+            .With<Position>()
+            .TermAt<Position>(0)
+            .Build();
+
+        world.QueryBuilder()
+            .With<Tag, Position>()
+            .TermAt<Position>(0)
+            .Build();
+
+        world.QueryBuilder()
+            .With<Tag>().Second<Position>()
+            .TermAt<Position>(0)
+            .Build();
+
+        Assert.Throws<Ecs.AssertionException>(() =>
+        {
+            world.QueryBuilder()
+                .With<Tag>().Second<Position>()
+                .TermAt<Tag>(0)
+                .Build();
+        });
+
+        Assert.Throws<Ecs.AssertionException>(() =>
+        {
+            world.QueryBuilder()
+                .With<Velocity>().Second<Position>()
+                .TermAt<Position>(0)
+                .Build();
+        });
+
+        Assert.Throws<Ecs.AssertionException>(() =>
+        {
+            world.Component<Tag>().Entity.Add(Ecs.PairIsTag);
+
+            world.QueryBuilder()
+                .With<Tag, Position>()
+                .TermAt<Position>(0)
+                .Build();
+
+            world.Component<Tag>().Entity.Remove(Ecs.PairIsTag);
+        });
+    }
 }

--- a/src/Flecs.NET/Core/QueryBuilder.cs
+++ b/src/Flecs.NET/Core/QueryBuilder.cs
@@ -1614,6 +1614,23 @@ public unsafe struct QueryBuilder : IDisposable, IEquatable<QueryBuilder>, IQuer
     }
 
     /// <summary>
+    ///     Sets the current term to the one with the provided type.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public ref QueryBuilder TermAt<T>()
+    {
+        for (int i = 0; i < _termCount; i++)
+        {
+            ecs_term_t term = _desc.terms[i];
+            if (Ecs.TypeIdIs<T>(World, term.id) || Ecs.TypeIdIs<T>(World, Ecs.Pair(term.first.id, term.second.id)))
+                return ref TermAt(i);
+        }
+        Ecs.Error("Term not found.");
+        return ref this;
+    }
+
+    /// <summary>
     ///     Sets the current term to the one at the provided index.
     /// </summary>
     /// <param name="termIndex"></param>
@@ -1629,6 +1646,17 @@ public unsafe struct QueryBuilder : IDisposable, IEquatable<QueryBuilder>, IQuer
             Ecs.Assert(ecs_term_is_initialized(ptr) == Utils.True, "Term is not initialized.");
 
         return ref this;
+    }
+
+    /// <summary>
+    ///     Sets the current term to the one at the provided index and asserts that the type matches.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public ref QueryBuilder TermAt<T>(int termIndex)
+    {
+        Ecs.Assert(Ecs.TypeIdIs<T>(World, CurrentTerm.id) || Ecs.TypeIdIs<T>(World, Ecs.Pair(CurrentTerm.first.id, CurrentTerm.second.id)), "Term type does not match.");
+        return ref TermAt(termIndex);
     }
 
     /// <summary>


### PR DESCRIPTION
Add support for TermAt<T> that finds term based on type and type checked term at that asserts term type after finding it at specific index.

Example use:

From:

```cs
        world
            .System<Window, Input, Camera>("UpdateCamera")
            .Kind(Ecs.PostLoad)
            .TermAt(0)
            .Singleton()
            .In()
            .TermAt(1)
            .Singleton()
            .In()
            .TermAt(2)
            .Singleton()
            .InOut()
            .Each(UpdateCamera);
```

To:

```cs
        world
            .System<Window, Input, Camera>("UpdateCamera")
            .Kind(Ecs.PostLoad)
            .TermAt<Window>()
            .Singleton()
            .In()
            .TermAt<Input>()
            .Singleton()
            .In()
            .TermAt<Camera>()
            .Singleton()
            .InOut()
            .Each(UpdateCamera);
```