### PR TITLE
Follow semver 2.0 for dev builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -52,7 +53,7 @@ jobs:
         shell: bash
         run: |
           if [ '${{ github.event.inputs.use-auto-generated-version }}' != 'false' ]; then
-            echo "FlecsVersionSuffix=-dev-$(date +'%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+            echo "FlecsVersionSuffix=build.$(git rev-list --count HEAD)" >> $GITHUB_ENV
           fi
 
       - name: Setup Osx Environment
@@ -61,7 +62,7 @@ jobs:
         run: |
           IOS_SDK=$(xcrun --sdk iphoneos --show-sdk-path)
           IOS_SIMULATOR_SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
-          
+
           echo "IOS_SDK=$IOS_SDK" >> $GITHUB_ENV
           echo "IOS_SIMULATOR_SDK=$IOS_SIMULATOR_SDK" >> $GITHUB_ENV
 
@@ -92,11 +93,11 @@ jobs:
         shell: bash
         run: |
           if [ '${{ github.event.inputs.nuget-registry }}' == 'NuGet' ]; then
-            dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Debug
-            dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix -c Release
+            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix -c Debug
+            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix -c Release
           else
-            dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -c Debug
-            dotnet pack --property:FlecsVersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -c Release
+            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -c Debug
+            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -c Release
           fi
 
       - name: Upload Artifacts

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ dotnet nuget add source --name "flecs.net" --username "YOUR_GITHUB_USERNAME" --p
 You can now reference any package from the [GitHub feed](https://github.com/BeanCheeseBurrito?tab=packages&repo_name=Flecs.NET)!
 
 ```console
-dotnet add PROJECT package Flecs.NET.Release --version 4.0.2-dev-2024-10-20-03-23-34
+dotnet add PROJECT package Flecs.NET.Release --version *-build.*
 ```
+
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -111,7 +112,7 @@ dotnet add PROJECT package Flecs.NET.Release --version 4.0.2-dev-2024-10-20-03-2
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Flecs.NET.Debug" Version="4.0.2-dev-2024-10-20-03-23-34"/>
+        <PackageReference Include="Flecs.NET.Debug" Version="*-build.*"/>
     </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,0 @@
-<Project>
-    <PropertyGroup>
-        <Version>$(Version)$(FlecsVersionSuffix)</Version>
-    </PropertyGroup>
-</Project>

--- a/src/Flecs.NET.Bindings/Flecs.NET.Bindings.csproj
+++ b/src/Flecs.NET.Bindings/Flecs.NET.Bindings.csproj
@@ -10,7 +10,7 @@
         <IsPackable>true</IsPackable>
         <IncludeContentInPack>true</IncludeContentInPack>
 
-        <Version>4.0.2</Version>
+        <VersionPrefix>4.0.2</VersionPrefix>
         <Title Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Bindings.Debug</Title>
         <Title Condition="'$(Configuration)' == 'Release'">Flecs.NET.Bindings.Release</Title>
         <Authors>BeanCheeseBurrito</Authors>

--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -10,7 +10,7 @@
         <IncludeContentInPack>true</IncludeContentInPack>
         <IncludeBuildOutput>false</IncludeBuildOutput>
 
-        <Version>4.0.2</Version>
+        <VersionPrefix>4.0.2</VersionPrefix>
         <Title Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Native.Debug</Title>
         <Title Condition="'$(Configuration)' == 'Release'">Flecs.NET.Native.Release</Title>
         <Authors>BeanCheeseBurrito</Authors>

--- a/src/Flecs.NET/Flecs.NET.csproj
+++ b/src/Flecs.NET/Flecs.NET.csproj
@@ -20,7 +20,7 @@
         <IsPackable>true</IsPackable>
         <IncludeContentInPack>true</IncludeContentInPack>
 
-        <Version>4.0.2</Version>
+        <VersionPrefix>4.0.2</VersionPrefix>
         <Title Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Debug</Title>
         <Title Condition="'$(Configuration)' == 'Release'">Flecs.NET.Release</Title>
         <Authors>BeanCheeseBurrito</Authors>
@@ -41,7 +41,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
 


### PR DESCRIPTION
- Switch to -build.<commit-number> for dev versions
- Use builtin dotnet VersionSuffix property instead of custom FlecsVersionSuffix
- Update README

Reference: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#pre-release-versions