### PR TITLE
Disable automatic NativeAOT linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ public record struct Velocity(float X, float Y);
 
 **Flecs.NET.Native - Precompiled native libraries**
 - Provides both shared and static libraries for Windows, MacOS, Linux, iOS, and WASM
-- Static libraries are automatically linked for NativeAOT builds (`$(FlecsStaticPath)` available for manual linking for other targets)
+- `$(FlecsStaticLibrary)` is provided for static linking in MSBuild projects
 - Packaged with Zig for dependency free cross-compilation everywhere
 
 ## NuGet

--- a/src/Flecs.NET.Native/buildTransitive/Flecs.NET.Native.props
+++ b/src/Flecs.NET.Native/buildTransitive/Flecs.NET.Native.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
-    <FlecsStaticPath>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)../static/$(RuntimeIdentifier)/native/'))</FlecsStaticPath>
     <IsWindowsRuntime Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.StartsWith('win-'))">true</IsWindowsRuntime>
+    <FlecsStaticPath>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)../static/$(RuntimeIdentifier)/native/'))</FlecsStaticPath>
+    <FlecsStaticLibrary Condition="'$(IsWindowsRuntime)' == 'true'">$(FlecsStaticPath)flecs.lib</FlecsStaticLibrary>
+    <FlecsStaticLibrary Condition="'$(IsWindowsRuntime)' != 'true'">$(FlecsStaticPath)libflecs.a</FlecsStaticLibrary>
   </PropertyGroup>
 </Project>

--- a/src/Flecs.NET.Native/buildTransitive/Flecs.NET.Native.targets
+++ b/src/Flecs.NET.Native/buildTransitive/Flecs.NET.Native.targets
@@ -1,7 +1,8 @@
 <Project>
-  <ItemGroup Condition="'$(PublishAot)' == 'true'">
+  <!-- FIXME: BindgenInternal.LoadDLLSymbol do not supports static linking
+  <ItemGroup Condition="'$(PublishAot)' == 'true' And Exists('$(FlecsStaticLibrary)')">
     <DirectPInvoke Include="flecs"/>
-    <NativeLibrary Condition="'$(IsWindowsRuntime)' == 'true'" Include="$(FlecsStaticPath)flecs.lib"/>
-    <NativeLibrary Condition="'$(IsWindowsRuntime)' != 'true'" Include="$(FlecsStaticPath)libflecs.a"/>
+    <NativeLibrary Include="$(FlecsStaticLibrary)"/>
   </ItemGroup>
+  -->
 </Project>


### PR DESCRIPTION
Currently `BindgenInternal.LoadDLLSymbol` do not supports statically linked libraries so for now disable automatic linking and add comment with explanation.