### PR TITLE
Move duplicate properties to Directory.Build

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,24 @@
 <Project>
     <PropertyGroup>
+        <VersionPrefix>4.0.2</VersionPrefix>
+        <Authors>BeanCheeseBurrito</Authors>
+        <Copyright>BeanCheeseBurrito</Copyright>
+        <PackageProjectUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</PackageProjectUrl>
+        <PackageIconUrl>https://raw.githubusercontent.com/SanderMertens/flecs/master/docs/img/logo_small.png</PackageIconUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</RepositoryUrl>
+        <RepositoryType>Github</RepositoryType>
+        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+        <DebugType>portable</DebugType>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <IsPackable>false</IsPackable>
         <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(ContinuousIntegrationBuild)' == ''">true</ContinuousIntegrationBuild>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+    <ItemGroup>
+        <Content Include="../../docs/icon.png" PackagePath="icon.png"/>
+    </ItemGroup>
+</Project>

--- a/src/Flecs.NET.Bindings/Flecs.NET.Bindings.csproj
+++ b/src/Flecs.NET.Bindings/Flecs.NET.Bindings.csproj
@@ -10,31 +10,10 @@
         <IsPackable>true</IsPackable>
         <IncludeContentInPack>true</IncludeContentInPack>
 
-        <VersionPrefix>4.0.2</VersionPrefix>
-        <Title Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Bindings.Debug</Title>
-        <Title Condition="'$(Configuration)' == 'Release'">Flecs.NET.Bindings.Release</Title>
-        <Authors>BeanCheeseBurrito</Authors>
-        <Copyright>BeanCheeseBurrito</Copyright>
+        <PackageId Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Bindings.Debug</PackageId>
+        <PackageId Condition="'$(Configuration)' == 'Release'">Flecs.NET.Bindings.Release</PackageId>
         <Description>Raw C# bindings for flecs</Description>
-        <PackageId>$(Title)</PackageId>
-        <PackageProjectUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</PackageProjectUrl>
-        <PackageIconUrl>https://raw.githubusercontent.com/SanderMertens/flecs/master/docs/img/logo_small.png</PackageIconUrl>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</RepositoryUrl>
-        <RepositoryType>Github</RepositoryType>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-
-        <DebugType>portable</DebugType>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
-
-    <ItemGroup>
-        <Content Include="../../docs/icon.png" PackagePath="icon.png"/>
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>

--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -17,16 +17,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
 
-        <VersionPrefix>4.0.2</VersionPrefix>
-        <Authors>BeanCheeseBurrito</Authors>
-        <Copyright>BeanCheeseBurrito</Copyright>
         <Description>Native libraries for flecs</Description>
-        <PackageProjectUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</PackageProjectUrl>
-        <PackageIconUrl>https://raw.githubusercontent.com/SanderMertens/flecs/master/docs/img/logo_small.png</PackageIconUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</RepositoryUrl>
-        <RepositoryType>Github</RepositoryType>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -38,14 +29,12 @@
         <When Condition="'$(Configuration)' == 'Debug'">
             <PropertyGroup>
                 <PackageId>Flecs.NET.Native.Debug</PackageId>
-                <Title>$(PackageId)</Title>
                 <ZigConfiguration>Debug</ZigConfiguration>
             </PropertyGroup>
         </When>
         <When Condition="'$(Configuration)' == 'Release'">
             <PropertyGroup>
                 <PackageId>Flecs.NET.Native.Release</PackageId>
-                <Title>$(PackageId)</Title>
                 <ZigConfiguration>ReleaseFast</ZigConfiguration>
             </PropertyGroup>
         </When>

--- a/src/Flecs.NET/Flecs.NET.csproj
+++ b/src/Flecs.NET/Flecs.NET.csproj
@@ -20,37 +20,14 @@
         <IsPackable>true</IsPackable>
         <IncludeContentInPack>true</IncludeContentInPack>
 
-        <VersionPrefix>4.0.2</VersionPrefix>
-        <Title Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Debug</Title>
-        <Title Condition="'$(Configuration)' == 'Release'">Flecs.NET.Release</Title>
-        <Authors>BeanCheeseBurrito</Authors>
-        <Copyright>BeanCheeseBurrito</Copyright>
+        <PackageId Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Debug</PackageId>
+        <PackageId Condition="'$(Configuration)' == 'Release'">Flecs.NET.Release</PackageId>
         <Description>High-level C# wrapper for flecs</Description>
-        <PackageId>$(Title)</PackageId>
-        <PackageProjectUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</PackageProjectUrl>
-        <PackageIconUrl>https://raw.githubusercontent.com/SanderMertens/flecs/master/docs/img/logo_small.png</PackageIconUrl>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/BeanCheeseBurrito/Flecs.NET</RepositoryUrl>
-        <RepositoryType>Github</RepositoryType>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-
-        <DebugType>portable</DebugType>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-
         <ProjectReference Include="..\Flecs.NET.Bindings\Flecs.NET.Bindings.csproj"/>
-        <ProjectReference Include="..\Flecs.NET.Native\Flecs.NET.Native.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Content Include="../../docs/icon.png" PackagePath="icon.png"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Move duplicate properties in projects to Directory.Build
- Fix icon for natives
- Remove duplicate dependency on Flecs.NET.native in Flecs.NET (it already depends on Bindings which depend on Flecs.NET.Native)