### PR TITLE
Fix spacing issue when enabling SoftAssert

### DIFF
--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -175,7 +175,7 @@
 
     <!-- Enable soft asserts if configured -->
     <PropertyGroup>
-        <ZigArgs Condition="'$(FlecsSoftAssert)' == 'True'">$(ZigArgs)-Dsoft-assert=true</ZigArgs>
+        <ZigArgs Condition="'$(FlecsSoftAssert)' == 'True'">$(ZigArgs) -Dsoft-assert=true</ZigArgs>
     </PropertyGroup>
 
     <!-- Here we need host not target toolset to compile/cross-compile -->


### PR DESCRIPTION
When ZigArgs are already set (for example for WASM or IOS build) when enabling soft asserts -Dsoft-assert is appended right at the end, causing the param to merge with previous one