### PR TITLE
Pass zig include headers to binding generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,6 @@ Reference the project and import the native libraries. You should now be able to
 
 ### Running the bindings generator
 Low-level bindings to the flecs C API are pre-generated and included in the [Flecs.NET.Bindings](https://github.com/BeanCheeseBurrito/Flecs.NET/tree/main/src/Flecs.NET.Bindings) project by default. If needed, you can run the following command to regenerate the bindings file.
-> [!NOTE]
-> The binding generator needs access to system headers on MacOS. Ensure that XCode is installed.
 ```console
 dotnet run --project src/Flecs.NET.Bindgen
 ```

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,4 +25,29 @@
         <Deterministic Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(Deterministic)' == ''">true</Deterministic>
         <AllowedOutputExtensionsInPackageBuildOutputFolder Condition="'$(FlecsPackPdb)' == 'true'">$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</HostArch>
+    </PropertyGroup>
+
+    <Choose>
+        <When Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+            <PropertyGroup>
+                <HostRuntime Condition="'$(HostArch)' == 'X64'">win-x64</HostRuntime>
+                <HostRuntime Condition="'$(HostArch)' == 'Arm64'">win-arm64</HostRuntime>
+            </PropertyGroup>
+        </When>
+        <When Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+            <PropertyGroup>
+                <HostRuntime Condition="'$(HostArch)' == 'X64'">linux-x64</HostRuntime>
+                <HostRuntime Condition="'$(HostArch)' == 'Arm64'">linux-arm64</HostRuntime>
+            </PropertyGroup>
+        </When>
+        <When Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+            <PropertyGroup>
+                <HostRuntime Condition="'$(HostArch)' == 'X64'">osx-x64</HostRuntime>
+                <HostRuntime Condition="'$(HostArch)' == 'Arm64'">osx-arm64</HostRuntime>
+            </PropertyGroup>
+        </When>
+    </Choose>
 </Project>

--- a/src/Flecs.NET.Bindgen/Flecs.NET.Bindgen.csproj
+++ b/src/Flecs.NET.Bindgen/Flecs.NET.Bindgen.csproj
@@ -13,6 +13,22 @@
 
     <ItemGroup>
         <PackageReference Include="Bindgen.NET" Version="0.1.14"/>
+        <PackageReference Include="Vezel.Zig.Toolsets.$(HostRuntime)" Version="0.13.0.1">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
+
+    <!-- Store the location of the zig lib folder as a global variable that can be accessed in code. -->
+    <ItemGroup>
+        <Compile Include="$(IntermediateOutputPath)BuildConstants.cs"/>
+    </ItemGroup>
+
+    <Target Name="GenerateConstants" BeforeTargets="CoreCompile">
+        <WriteLinesToFile
+            File="$(IntermediateOutputPath)BuildConstants.cs"
+            Lines='public static class BuildConstants { public const string ZigLibPath = @"$(ZigLibPath)"%3B }'
+            Overwrite="true"/>
+    </Target>
 
 </Project>

--- a/src/Flecs.NET.Bindgen/Program.cs
+++ b/src/Flecs.NET.Bindgen/Program.cs
@@ -23,7 +23,7 @@ BindingOptions bindingOptions = new()
 
     SuppressedWarnings = { "CS8981" },
 
-    IncludeBuiltInClangHeaders = true,
+    SystemIncludeDirectories = { Path.Combine(BuildConstants.ZigLibPath, "include") },
 
     InputFile = GetFlecsHeaderPath(),
     OutputFile = GetBindingsOutputPath(),
@@ -34,9 +34,11 @@ BindingOptions bindingOptions = new()
 };
 
 if (OperatingSystem.IsMacOS())
-    bindingOptions.SystemIncludeDirectories.Add(GetMacOsHeaders());
+    bindingOptions.SystemIncludeDirectories.Add(Path.Combine(BuildConstants.ZigLibPath, "libc", "include", "any-macos-any"));
 
 BindingGenerator.Generate(bindingOptions);
+
+return;
 
 string GetFlecsHeaderPath([CallerFilePath] string filePath = "")
 {
@@ -46,29 +48,4 @@ string GetFlecsHeaderPath([CallerFilePath] string filePath = "")
 string GetBindingsOutputPath([CallerFilePath] string filePath = "")
 {
     return Path.GetFullPath(Path.Combine(filePath, "..", "..", "Flecs.NET.Bindings", "Flecs.g.cs"));
-}
-
-string GetMacOsHeaders()
-{
-    using Process process = new()
-    {
-        StartInfo = new ProcessStartInfo
-        {
-            FileName = "xcrun",
-            Arguments = "--sdk macosx --show-sdk-path",
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        }
-    };
-
-    process.Start();
-    process.WaitForExit();
-
-    string path = process.StandardOutput.ReadToEnd().Trim();
-
-    if (!Directory.Exists(path))
-        throw new DirectoryNotFoundException("Couldn't find system headers. Install XCode.");
-
-    return path + "/usr/include";
 }

--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -11,17 +11,13 @@
         <IncludeBuildFiles>false</IncludeBuildFiles>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
-        <NoWarn>$(NoWarn);CS2008</NoWarn>
+        <NoWarn>$(NoWarn);CS2008;NU5128</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
 
         <Description>Native libraries for flecs</Description>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</HostArch>
     </PropertyGroup>
 
     <!-- We want 2 separate natives packages for debug and release modes -->
@@ -36,28 +32,6 @@
             <PropertyGroup>
                 <PackageId>Flecs.NET.Native.Release</PackageId>
                 <ZigConfiguration>ReleaseFast</ZigConfiguration>
-            </PropertyGroup>
-        </When>
-    </Choose>
-
-    <!-- As we are cross-compiling, RID != host runtime so we need to determine it for later -->
-    <Choose>
-        <When Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-            <PropertyGroup>
-                <HostRuntime Condition="'$(HostArch)' == 'X64'">win-x64</HostRuntime>
-                <HostRuntime Condition="'$(HostArch)' == 'Arm64'">win-arm64</HostRuntime>
-            </PropertyGroup>
-        </When>
-        <When Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-            <PropertyGroup>
-                <HostRuntime Condition="'$(HostArch)' == 'X64'">linux-x64</HostRuntime>
-                <HostRuntime Condition="'$(HostArch)' == 'Arm64'">linux-arm64</HostRuntime>
-            </PropertyGroup>
-        </When>
-        <When Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-            <PropertyGroup>
-                <HostRuntime Condition="'$(HostArch)' == 'X64'">osx-x64</HostRuntime>
-                <HostRuntime Condition="'$(HostArch)' == 'Arm64'">osx-arm64</HostRuntime>
             </PropertyGroup>
         </When>
     </Choose>


### PR DESCRIPTION
This PR passes zig's include headers to the binding generator to avoid depending on the user having platform-specific headers installed.