### PR TITLE
Run bindgen and codegen during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,6 @@ jobs:
         shell: bash
         run: dotnet restore
 
-      - name: Generate Bindings
-        shell: bash
-        run: dotnet run --project src/Flecs.NET.Bindgen
-
       - name: Build Projects
         shell: bash
         run: |
@@ -92,28 +88,25 @@ jobs:
         working-directory: src/Flecs.NET.Native
         run: |
           dotnet build -c Debug -r linux-x64
-          dotnet build -c Release -r linux-x64
           dotnet build -c Debug -r linux-arm64
-          dotnet build -c Release -r linux-arm64
-
           dotnet build -c Debug -r osx-x64
-          dotnet build -c Release -r osx-x64
           dotnet build -c Debug -r osx-arm64
-          dotnet build -c Release -r osx-arm64
-
           dotnet build -c Debug -r win-x64
-          dotnet build -c Release -r win-x64
           dotnet build -c Debug -r win-arm64
-          dotnet build -c Release -r win-arm64
-
           dotnet build -c Debug -r browser-wasm
-          dotnet build -c Release -r browser-wasm
-
           dotnet build -c Debug -r iossimulator-x64
-          dotnet build -c Release -r iossimulator-x64
           dotnet build -c Debug -r iossimulator-arm64
-          dotnet build -c Release -r iossimulator-arm64
           dotnet build -c Debug -r ios-arm64
+
+          dotnet build -c Release -r linux-x64
+          dotnet build -c Release -r linux-arm64
+          dotnet build -c Release -r osx-x64
+          dotnet build -c Release -r osx-arm64
+          dotnet build -c Release -r win-x64
+          dotnet build -c Release -r win-arm64
+          dotnet build -c Release -r browser-wasm
+          dotnet build -c Release -r iossimulator-x64
+          dotnet build -c Release -r iossimulator-arm64
           dotnet build -c Release -r ios-arm64
 
       - name: Run Tests
@@ -124,11 +117,11 @@ jobs:
         shell: bash
         run: |
           if [ '${{ github.event.inputs.nuget-registry }}' == 'NuGet' ]; then
-            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix -p:SkipNatives=true -c Debug
-            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix -p:SkipNatives=true -c Release
+            dotnet pack -p:VersionSuffix=$FlecsVersionSuffix -p:SkipNatives=true -p:SkipGen=true -c Debug
+            dotnet pack -p:VersionSuffix=$FlecsVersionSuffix -p:SkipNatives=true -p:SkipGen=true -c Release
           else
-            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -p:SkipNatives=true -c Debug
-            dotnet pack --property:VersionSuffix=$FlecsVersionSuffix --property:FlecsPackPdb=true -p:SkipNatives=true -c Release
+            dotnet pack -p:VersionSuffix=$FlecsVersionSuffix -p:FlecsPackPdb=true -p:SkipNatives=true -p:SkipGen=true -c Debug
+            dotnet pack -p:VersionSuffix=$FlecsVersionSuffix -p:FlecsPackPdb=true -p:SkipNatives=true -p:SkipGen=true -c Release
           fi
 
       - name: Upload Artifacts

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Run the following command on the solution to restore all project dependencies.
 dotnet restore
 ```
 ### Build Flecs.NET
-Compile the wrapper and native libraries. The [zig](https://ziglang.org/learn/overview/#cross-compiling-is-a-first-class-use-case) compiler will automatically be downloaded and cached in your local nuget package folder. Native libraries will be cross-compiled for linux, macos, and windows.
+Compile the wrapper, native libraries and generate necessary code. The [zig](https://ziglang.org/learn/overview/#cross-compiling-is-a-first-class-use-case) compiler will automatically be downloaded and cached in your local nuget package folder. Native libraries will be cross-compiled for linux, macos, and windows.
 ```console
 dotnet build
 ```
@@ -178,17 +178,6 @@ Reference the project and import the native libraries. You should now be able to
     </ItemGroup>
 
 </Project>
-```
-
-### Running the bindings generator
-Low-level bindings to the flecs C API are pre-generated and included in the [Flecs.NET.Bindings](https://github.com/BeanCheeseBurrito/Flecs.NET/tree/main/src/Flecs.NET.Bindings) project by default. If needed, you can run the following command to regenerate the bindings file.
-```console
-dotnet run --project src/Flecs.NET.Bindgen
-```
-### Running the code generator
-**Flecs.NET** relies on code generation to avoid manual code duplication. If any changes are made to the [Flecs.NET.Codegen](https://github.com/BeanCheeseBurrito/Flecs.NET/tree/main/src/Flecs.NET.Codegen) project, you can run the following command to rerun the code generators. The generated files will be output to this [folder](https://github.com/BeanCheeseBurrito/Flecs.NET/tree/main/src/Flecs.NET/Generated).
-```console
-dotnet run --project src/Flecs.NET.Codegen
 ```
 
 ## Contributing

--- a/src/Flecs.NET.Bindgen/Flecs.NET.Bindgen.csproj
+++ b/src/Flecs.NET.Bindgen/Flecs.NET.Bindgen.csproj
@@ -19,16 +19,8 @@
         </PackageReference>
     </ItemGroup>
 
-    <!-- Store the location of the zig lib folder as a global variable that can be accessed in code. -->
-    <ItemGroup>
-        <Compile Include="$(IntermediateOutputPath)BuildConstants.cs"/>
-    </ItemGroup>
-
-    <Target Name="GenerateConstants" BeforeTargets="CoreCompile">
-        <WriteLinesToFile
-            File="$(IntermediateOutputPath)BuildConstants.cs"
-            Lines='public static class BuildConstants { public const string ZigLibPath = @"$(ZigLibPath)"%3B }'
-            Overwrite="true"/>
+    <Target Name="Generate" AfterTargets="Build" Condition="'$(SkipGen)' != 'true'">
+        <Exec Command="dotnet &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ZigLibPath)&quot;" />
     </Target>
 
 </Project>

--- a/src/Flecs.NET.Bindgen/Program.cs
+++ b/src/Flecs.NET.Bindgen/Program.cs
@@ -1,6 +1,8 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Bindgen.NET;
+
+var zigLibPath = args[0];
 
 BindingOptions bindingOptions = new()
 {
@@ -23,7 +25,7 @@ BindingOptions bindingOptions = new()
 
     SuppressedWarnings = { "CS8981" },
 
-    SystemIncludeDirectories = { Path.Combine(BuildConstants.ZigLibPath, "include") },
+    SystemIncludeDirectories = { Path.Combine(zigLibPath, "include") },
 
     InputFile = GetFlecsHeaderPath(),
     OutputFile = GetBindingsOutputPath(),
@@ -34,7 +36,7 @@ BindingOptions bindingOptions = new()
 };
 
 if (OperatingSystem.IsMacOS())
-    bindingOptions.SystemIncludeDirectories.Add(Path.Combine(BuildConstants.ZigLibPath, "libc", "include", "any-macos-any"));
+    bindingOptions.SystemIncludeDirectories.Add(Path.Combine(zigLibPath, "libc", "include", "any-macos-any"));
 
 BindingGenerator.Generate(bindingOptions);
 

--- a/src/Flecs.NET.Codegen/Flecs.NET.Codegen.csproj
+++ b/src/Flecs.NET.Codegen/Flecs.NET.Codegen.csproj
@@ -14,4 +14,8 @@
         <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     </PropertyGroup>
 
+    <Target Name="Generate" AfterTargets="Build" Condition="'$(SkipGen)' != 'true'">
+        <Exec Command="dotnet &quot;$(TargetDir)$(TargetFileName)&quot;" />
+    </Target>
+
 </Project>


### PR DESCRIPTION
- Instead or requiring manual dotnet run add targets that automatically run built codegen and bindgen projects
- Simplify passing zigLibPath thanks to above change
- Run debug builds first and then release builds when building natives to possibly speedup build process