### PR TITLE
Bundle zig's compiler rt when compiling flecs native libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,28 +92,25 @@ jobs:
         working-directory: src/Flecs.NET.Native
         run: |
           dotnet build -c Debug -r linux-x64
-          dotnet build -c Release -r linux-x64
           dotnet build -c Debug -r linux-arm64
-          dotnet build -c Release -r linux-arm64
-
           dotnet build -c Debug -r osx-x64
-          dotnet build -c Release -r osx-x64
           dotnet build -c Debug -r osx-arm64
-          dotnet build -c Release -r osx-arm64
-
           dotnet build -c Debug -r win-x64
-          dotnet build -c Release -r win-x64
           dotnet build -c Debug -r win-arm64
-          dotnet build -c Release -r win-arm64
-
           dotnet build -c Debug -r browser-wasm
-          dotnet build -c Release -r browser-wasm
-
           dotnet build -c Debug -r iossimulator-x64
-          dotnet build -c Release -r iossimulator-x64
           dotnet build -c Debug -r iossimulator-arm64
-          dotnet build -c Release -r iossimulator-arm64
           dotnet build -c Debug -r ios-arm64
+
+          dotnet build -c Release -r linux-x64
+          dotnet build -c Release -r linux-arm64
+          dotnet build -c Release -r osx-x64
+          dotnet build -c Release -r osx-arm64
+          dotnet build -c Release -r win-x64
+          dotnet build -c Release -r win-arm64
+          dotnet build -c Release -r browser-wasm
+          dotnet build -c Release -r iossimulator-x64
+          dotnet build -c Release -r iossimulator-arm64
           dotnet build -c Release -r ios-arm64
 
       - name: Run Tests
@@ -133,7 +130,7 @@ jobs:
 
       - name: Upload Artifacts
         if: matrix.os == 'macos-13'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Nuget Packages
           path: |

--- a/native/windows.c
+++ b/native/windows.c
@@ -1,0 +1,5 @@
+// Temporary fix for undefined symbol errors when statically linking on windows.
+void __mingw_vsnprintf() { }
+void __mingw_vfprintf() { }
+void __isnanf() { }
+void __fpclassifyf() { }

--- a/src/Flecs.NET.Native/Flecs.NET.Native.csproj
+++ b/src/Flecs.NET.Native/Flecs.NET.Native.csproj
@@ -136,9 +136,9 @@
         </Otherwise>
     </Choose>
 
-    <!-- Enable soft asserts if configured -->
+    <!-- Path to compiler_rt.zig -->
     <PropertyGroup>
-        <ZigArgs Condition="'$(FlecsSoftAssert)' == 'True'">$(ZigArgs) -Dsoft-assert=true</ZigArgs>
+        <ZigArgs>$(ZigArgs) -Dcompiler-rt-path="$(ZigLibPath)/compiler_rt.zig"</ZigArgs>
     </PropertyGroup>
 
     <!-- Here we need host not target toolset to compile/cross-compile -->


### PR DESCRIPTION
This PR updates the zig build script to bundle zig's compiler runtime with the flecs native libraries. This change is needed to fix an issue where linking the static libraries on Windows would result in undefined symbol errors.