### PR TITLE
Unified Flecs.NET NuGet package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
       - name: Pack Nuget Packages
         shell: bash
         run: |
+          dotnet pack --property:VersionSuffix=$FlecsVersionSuffix -p:SkipNatives=true -p:BuildSelectorPackage=true
+          
           if [ '${{ github.event.inputs.nuget-registry }}' == 'NuGet' ]; then
             dotnet pack --property:VersionSuffix=$FlecsVersionSuffix -p:SkipNatives=true -c Debug
             dotnet pack --property:VersionSuffix=$FlecsVersionSuffix -p:SkipNatives=true -c Release

--- a/src/Flecs.NET/Flecs.NET.csproj
+++ b/src/Flecs.NET/Flecs.NET.csproj
@@ -13,21 +13,44 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
         <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
-        <NoWarn>$(NoWarn);CA1000;CA1024,CA1034;CA1051;CA1062;CA1720;CA2207;CA2225;CS9087;CS9084;CS8500</NoWarn>
+        <NoWarn>$(NoWarn);CA1000;CA1024,CA1034;CA1051;CA1062;CA1720;CA2207;CA2225;CS9087;CS9084;CS8500;NU5128</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <IncludeContentInPack>true</IncludeContentInPack>
-
-        <PackageId Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Debug</PackageId>
-        <PackageId Condition="'$(Configuration)' == 'Release'">Flecs.NET.Release</PackageId>
         <Description>High-level C# wrapper for flecs</Description>
     </PropertyGroup>
+    
+    <Choose>
+        <!-- 
+            Build the Flecs.NET package. It contains a single msbuild .targets file that automatically references the
+            debug or release builds based on the consuming project's $(Optimize) property.
+        -->
+        <When Condition="'$(BuildSelectorPackage)' == 'True'">
+            <PropertyGroup>
+                <PackageId>Flecs.NET</PackageId>
+                <IncludeSymbols>false</IncludeSymbols>
+                <IncludeBuildOutput>false</IncludeBuildOutput>
+                <NoBuild>true</NoBuild>
+            </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <ProjectReference Include="..\Flecs.NET.Bindings\Flecs.NET.Bindings.csproj"/>
-    </ItemGroup>
+            <ItemGroup>
+                <None Pack="true" Include="buildTransitive/Flecs.NET.targets" PackagePath="buildTransitive/Flecs.NET.targets" />
+            </ItemGroup>
+        </When>
+        <!-- Build the Flecs.NET.Debug or Flecs.NET.Release package. This package contains the actual compiled dll. -->
+        <Otherwise>
+            <PropertyGroup>
+                <PackageId Condition="'$(Configuration)' == 'Debug'">Flecs.NET.Debug</PackageId>
+                <PackageId Condition="'$(Configuration)' == 'Release'">Flecs.NET.Release</PackageId>
+            </PropertyGroup>
+            
+            <ItemGroup>
+                <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+                <ProjectReference Include="..\Flecs.NET.Bindings\Flecs.NET.Bindings.csproj"/>
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
 
 </Project>

--- a/src/Flecs.NET/buildTransitive/Flecs.NET.targets
+++ b/src/Flecs.NET/buildTransitive/Flecs.NET.targets
@@ -1,0 +1,14 @@
+<Project>
+    <!-- Go up 2 levels to get the NuGet package version. -->
+    <PropertyGroup>
+        <FlecsNugetVersion>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..'))</FlecsNugetVersion>
+        <FlecsNugetVersion>$([System.IO.Path]::GetDirectoryName('$(FlecsNugetVersion)'))</FlecsNugetVersion>
+        <FlecsNugetVersion>$([System.IO.Path]::GetFileName('$(FlecsNugetVersion)'))</FlecsNugetVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Flecs.NET.Release" Version="$(FlecsNugetVersion)" Condition="'$(Optimize)' == 'True'"/>
+        <PackageReference Include="Flecs.NET.Debug" Version="$(FlecsNugetVersion)" Condition="'$(Optimize)' != 'True'"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Currently, the wrapper ships as two separate NuGet packages. (``Flecs.NET.Debug`` and ``Flecs.NET.Release``) This PR adds a new ``Flecs.NET`` NuGet package that automatically switches between the debug and release version based on the consuming project's ``$(Optimize)`` property.