### PR TITLE
Implement static type hook interfaces

### DIFF
--- a/src/Flecs.NET/Core/Hooks/ICopyHook.cs
+++ b/src/Flecs.NET/Core/Hooks/ICopyHook.cs
@@ -1,0 +1,24 @@
+namespace Flecs.NET.Core.Hooks;
+
+/// <summary>
+///     Interface for registering a copy hook callback with the provided type.
+/// </summary>
+/// <typeparam name="T">The component type.</typeparam>
+public interface ICopyHook<T>
+{
+    /// <summary>
+    ///     The copy hook callback
+    /// </summary>
+    /// <param name="dst">The reference to the component's copy destination.</param>
+    /// <param name="src">The reference to the component's copy source.</param>
+    /// <param name="typeInfo">The component's type info.</param>
+    public static abstract void Copy(ref T dst, ref T src, TypeInfo typeInfo);
+
+    internal static unsafe class FunctionPointer<TInterface> where TInterface : ICopyHook<T>
+    {
+        public static delegate*<ref T, ref T, TypeInfo, void> Get()
+        {
+            return &TInterface.Copy;
+        }
+    }
+}

--- a/src/Flecs.NET/Core/Hooks/ICtorHook.cs
+++ b/src/Flecs.NET/Core/Hooks/ICtorHook.cs
@@ -1,0 +1,23 @@
+namespace Flecs.NET.Core.Hooks;
+
+/// <summary>
+///     Interface for registering a ctor hook callback with the provided type.
+/// </summary>
+/// <typeparam name="T">The component type.</typeparam>
+public interface ICtorHook<T>
+{
+    /// <summary>
+    ///     The ctor hook callback.
+    /// </summary>
+    /// <param name="data">The reference to the component.</param>
+    /// <param name="typeInfo">The component's type info.</param>
+    public static abstract void Ctor(ref T data, TypeInfo typeInfo);
+
+    internal static unsafe class FunctionPointer<TInterface> where TInterface : ICtorHook<T>
+    {
+        public static delegate*<ref T, TypeInfo, void> Get()
+        {
+            return &TInterface.Ctor;
+        }
+    }
+}

--- a/src/Flecs.NET/Core/Hooks/IDtorHook.cs
+++ b/src/Flecs.NET/Core/Hooks/IDtorHook.cs
@@ -1,0 +1,23 @@
+namespace Flecs.NET.Core.Hooks;
+
+/// <summary>
+///     Interface for registering a dtor hook callback with the provided type.
+/// </summary>
+/// <typeparam name="T">The component type.</typeparam>
+public interface IDtorHook<T>
+{
+    /// <summary>
+    ///     The dtor hook callback.
+    /// </summary>
+    /// <param name="data">The reference to the component.</param>
+    /// <param name="typeInfo">The component's type info.</param>
+    public static abstract void Dtor(ref T data, TypeInfo typeInfo);
+
+    internal static unsafe class FunctionPointer<TInterface> where TInterface : IDtorHook<T>
+    {
+        public static delegate*<ref T, TypeInfo, void> Get()
+        {
+            return &TInterface.Dtor;
+        }
+    }
+}

--- a/src/Flecs.NET/Core/Hooks/IMoveHook.cs
+++ b/src/Flecs.NET/Core/Hooks/IMoveHook.cs
@@ -1,0 +1,24 @@
+namespace Flecs.NET.Core.Hooks;
+
+/// <summary>
+///     Interface for registering a move hook callback with the provided type.
+/// </summary>
+/// <typeparam name="T">The component type.</typeparam>
+public interface IMoveHook<T>
+{
+    /// <summary>
+    ///     The move hook callback
+    /// </summary>
+    /// <param name="dst">The reference to the component's move destination.</param>
+    /// <param name="src">The reference to the component's move source.</param>
+    /// <param name="typeInfo">The component's type info.</param>
+    public static abstract void Move(ref T dst, ref T src, TypeInfo typeInfo);
+
+    internal static unsafe class FunctionPointer<TInterface> where TInterface : IMoveHook<T>
+    {
+        public static delegate*<ref T, ref T, TypeInfo, void> Get()
+        {
+            return &TInterface.Move;
+        }
+    }
+}

--- a/src/Flecs.NET/Core/Hooks/IOnAddHook.cs
+++ b/src/Flecs.NET/Core/Hooks/IOnAddHook.cs
@@ -1,0 +1,24 @@
+namespace Flecs.NET.Core.Hooks;
+
+/// <summary>
+///     Interface for registering an on add hook callback with the provided type.
+/// </summary>
+/// <typeparam name="T">The component type.</typeparam>
+public interface IOnAddHook<T>
+{
+    /// <summary>
+    ///     The on add hook callback.
+    /// </summary>
+    /// <param name="it">The iterator.</param>
+    /// <param name="i">The entity row.</param>
+    /// <param name="data">The reference to the component.</param>
+    public static abstract void OnAdd(Iter it, int i, ref T data);
+
+    internal static unsafe class FunctionPointer<TInterface> where TInterface : IOnAddHook<T>
+    {
+        public static delegate*<Iter, int, ref T, void> Get()
+        {
+            return &TInterface.OnAdd;
+        }
+    }
+}

--- a/src/Flecs.NET/Core/Hooks/IOnRemoveHook.cs
+++ b/src/Flecs.NET/Core/Hooks/IOnRemoveHook.cs
@@ -1,0 +1,24 @@
+namespace Flecs.NET.Core.Hooks;
+
+/// <summary>
+///     Interface for registering an on remove hook callback with the provided type.
+/// </summary>
+/// <typeparam name="T">The component type.</typeparam>
+public interface IOnRemoveHook<T>
+{
+    /// <summary>
+    ///     The on remove hook callback.
+    /// </summary>
+    /// <param name="it">The iterator.</param>
+    /// <param name="i">The entity row.</param>
+    /// <param name="data">The reference to the component.</param>
+    public static abstract void OnRemove(Iter it, int i, ref T data);
+
+    internal static unsafe class FunctionPointer<TInterface> where TInterface : IOnRemoveHook<T>
+    {
+        public static delegate*<Iter, int, ref T, void> Get()
+        {
+            return &TInterface.OnRemove;
+        }
+    }
+}

--- a/src/Flecs.NET/Core/Hooks/IOnSetHook.cs
+++ b/src/Flecs.NET/Core/Hooks/IOnSetHook.cs
@@ -1,0 +1,24 @@
+namespace Flecs.NET.Core.Hooks;
+
+/// <summary>
+///     Interface for registering an on set hook callback with the provided type.
+/// </summary>
+/// <typeparam name="T">The component type.</typeparam>
+public interface IOnSetHook<T>
+{
+    /// <summary>
+    ///     The on set hook callback.
+    /// </summary>
+    /// <param name="it">The iterator.</param>
+    /// <param name="i">The entity row.</param>
+    /// <param name="data">The reference to the component.</param>
+    public static abstract void OnSet(Iter it, int i, ref T data);
+
+    internal static unsafe class FunctionPointer<TInterface> where TInterface : IOnSetHook<T>
+    {
+        public static delegate*<Iter, int, ref T, void> Get()
+        {
+            return &TInterface.OnSet;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new way of registering type hook callbacks. You can implement any of the following interfaces and the callback will automatically be used when the component is first registered.
- ICtorHook<T>
- IDtorHook<T>
- ICopyHook<T>
- IMoveHook<T>
- IOnAddHook<T>
- IOnSetHook<T>
- IOnRemoveHook<T>

```cs
public record struct Position(int X, int Y) :
    ICtorHook<Position>,
    IDtorHook<Position>,
    ICopyHook<Position>,
    IMoveHook<Position>,
    IOnAddHook<Position>,
    IOnSetHook<Position>,
    IOnRemoveHook<Position>
{
    public static void Ctor(ref Position data, TypeInfo _) { }
    public static void Dtor(ref Position data, TypeInfo _) { }
    public static void Copy(ref Position dst, ref Position src, TypeInfo _) { }
    public static void Move(ref Position dst, ref Position src, TypeInfo _) { }
    public static void OnAdd(Iter it, int i, ref Position data) { }
    public static void OnSet(Iter it, int i, ref Position data) { }
    public static void OnRemove(Iter it, int i, ref Position data) { }
}

using World world = World.Create();
world.Entity().Add<Position>(); // Hook callbacks will get registered the first time a component is used.
```