### PR TITLE
Use in modifier for .Set() and .SetAutoOverride()

### DIFF
--- a/src/Flecs.NET.Codegen/Generators/Entity.cs
+++ b/src/Flecs.NET.Codegen/Generators/Entity.cs
@@ -1178,101 +1178,52 @@ public class Entity : GeneratorBase
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-                public ref {{typeName}} SetAutoOverride<T>(T component)
+                /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+                public ref {{typeName}} SetAutoOverride<T>(in T component)
                 {
-                    Entity.SetAutoOverride(component);
+                    Entity.SetAutoOverride(in component);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-                public ref {{typeName}} SetAutoOverride<T>(ref T component)
+                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+                public ref {{typeName}} SetAutoOverride<TFirst>(ulong second, in TFirst component)
                 {
-                    Entity.SetAutoOverride(ref component);
+                    Entity.SetAutoOverride(second, in component);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst>(ulong second, TFirst component)
+                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(in TFirst component)
                 {
-                    Entity.SetAutoOverride(second, component);
+                    Entity.SetAutoOverride<TFirst, TSecond>(in component);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(in TSecond component)
                 {
-                    Entity.SetAutoOverride(second, ref component);
+                    Entity.SetAutoOverride<TFirst, TSecond>(in component);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TFirst component)
+                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
                 {
-                    Entity.SetAutoOverride<TFirst, TSecond>(component);
+                    Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
                 {
-                    Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+                    Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TSecond component)
+                /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+                public ref {{typeName}} SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
                 {
-                    Entity.SetAutoOverride<TFirst, TSecond>(component);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-                {
-                    Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-                {
-                    Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-                {
-                    Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-                {
-                    Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-                public ref {{typeName}} SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-                {
-                    Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-                public ref {{typeName}} SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-                {
-                    Entity.SetAutoOverrideSecond(first, component);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-                public ref {{typeName}} SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-                {
-                    Entity.SetAutoOverrideSecond(first, ref component);
+                    Entity.SetAutoOverrideSecond(first, in component);
                     return ref this;
                 }
             
@@ -1486,101 +1437,52 @@ public class Entity : GeneratorBase
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.Set{T}(T)"/>
-                public ref {{typeName}} Set<T>(T data)
+                /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+                public ref {{typeName}} Set<T>(in T data)
                 {
-                    Entity.Set(data);
+                    Entity.Set(in data);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-                public ref {{typeName}} Set<TFirst>(ulong second, TFirst data)
+                /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+                public ref {{typeName}} Set<TFirst>(ulong second, in TFirst data)
                 {
-                    Entity.Set(second, data);
+                    Entity.Set(second, in data);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(TSecond data)
+                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+                public ref {{typeName}} Set<TFirst, TSecond>(in TSecond data)
                 {
-                    Entity.Set<TFirst, TSecond>(data);
+                    Entity.Set<TFirst, TSecond>(in data);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(TFirst data)
+                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+                public ref {{typeName}} Set<TFirst, TSecond>(in TFirst data)
                 {
-                    Entity.Set<TFirst, TSecond>(data);
+                    Entity.Set<TFirst, TSecond>(in data);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+                public ref {{typeName}} Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
                 {
-                    Entity.Set<TFirst, TSecond>(second, data);
+                    Entity.Set<TFirst, TSecond>(second, in data);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+                public ref {{typeName}} Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
                 {
-                    Entity.Set<TFirst, TSecond>(first, data);
+                    Entity.Set<TFirst, TSecond>(first, in data);
                     return ref this;
                 }
             
-                /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-                public ref {{typeName}} SetSecond<TSecond>(ulong first, TSecond data)
+                /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+                public ref {{typeName}} SetSecond<TSecond>(ulong first, in TSecond data)
                 {
-                    Entity.SetSecond(first, data);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-                public ref {{typeName}} Set<T>(ref T data)
-                {
-                    Entity.Set(ref data);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-                public ref {{typeName}} Set<TFirst>(ulong second, ref TFirst data)
-                {
-                    Entity.Set(second, ref data);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(ref TSecond data)
-                {
-                    Entity.Set<TFirst, TSecond>(ref data);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(ref TFirst data)
-                {
-                    Entity.Set<TFirst, TSecond>(ref data);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-                {
-                    Entity.Set<TFirst, TSecond>(second, ref data);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-                public ref {{typeName}} Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-                {
-                    Entity.Set<TFirst, TSecond>(first, ref data);
-                    return ref this;
-                }
-            
-                /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-                public ref {{typeName}} SetSecond<TSecond>(ulong first, ref TSecond data)
-                {
-                    Entity.SetSecond(first, ref data);
+                    Entity.SetSecond(first, in data);
                     return ref this;
                 }
             

--- a/src/Flecs.NET.Examples/Entities/SettingComponents.cs
+++ b/src/Flecs.NET.Examples/Entities/SettingComponents.cs
@@ -19,7 +19,7 @@ public static unsafe class Entities_SettingComponents
         // Set data for a typed component using a copy or reference.
         Position position = new(1, 1);
         entity.Set(position);
-        entity.Set(ref position);
+        entity.Set(in position);
 
         // Set data for a typed component using a pointer.
         Velocity velocity = new(2, 2);

--- a/src/Flecs.NET/Core/Ecs/Module.cs
+++ b/src/Flecs.NET/Core/Ecs/Module.cs
@@ -31,7 +31,7 @@ public static unsafe partial class Ecs
         if (!Type<T>.IsTag)
         {
             module.Add(EcsSparse);
-            world.Set(ref moduleInstance);
+            world.Set(in moduleInstance);
         }
 
         return module;

--- a/src/Flecs.NET/Core/Entity.cs
+++ b/src/Flecs.NET/Core/Entity.cs
@@ -2108,173 +2108,88 @@ public unsafe partial struct Entity : IEquatable<Entity>, IEntity<Entity>
     /// <summary>
     ///     Set component, mark component for auto-overriding.
     /// </summary>
-    /// <param name="component"></param>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<T>(T component)
+    /// <param name="component">The component data.</param>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <returns>Reference to self.</returns>
+    public ref Entity SetAutoOverride<T>(in T component)
     {
-        return ref SetAutoOverride(ref component);
-    }
-
-    /// <summary>
-    ///     Set component, mark component for auto-overriding.
-    /// </summary>
-    /// <param name="component"></param>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<T>(ref T component)
-    {
-        return ref AutoOverride<T>().Set(ref component);
+        return ref AutoOverride<T>().Set(in component);
     }
 
     /// <summary>
     ///     Set pair, mark component for auto-overriding.
     /// </summary>
-    /// <param name="second"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <param name="second">The second id of the pair.</param>
+    /// <param name="component">The component data.</param>
+    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
+    /// <returns>Reference to self.</returns>
+    public ref Entity SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        return ref SetAutoOverride(second, ref component);
+        return ref AutoOverride<TFirst>(second).Set(second, in component);
     }
 
     /// <summary>
     ///     Set pair, mark component for auto-overriding.
     /// </summary>
-    /// <param name="second"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <param name="component">The component data.</param>
+    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
+    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
+    /// <returns>Reference to self.</returns>
+    public ref Entity SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        return ref AutoOverride<TFirst>(second).Set(second, ref component);
+        return ref AutoOverride<TFirst, TSecond>().Set<TFirst, TSecond>(in component);
     }
 
     /// <summary>
     ///     Set pair, mark component for auto-overriding.
     /// </summary>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <param name="component">The component data.</param>
+    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
+    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
+    /// <returns>Reference to self.</returns>
+    public ref Entity SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        return ref SetAutoOverride<TFirst, TSecond>(ref component);
+        return ref AutoOverride<TFirst, TSecond>().Set<TFirst, TSecond>(in component);
     }
 
     /// <summary>
     ///     Set pair, mark component for auto-overriding.
     /// </summary>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(ref TFirst component)
-    {
-        return ref AutoOverride<TFirst, TSecond>().Set<TFirst, TSecond>(ref component);
-    }
-
-    /// <summary>
-    ///     Set pair, mark component for auto-overriding.
-    /// </summary>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(TSecond component)
-    {
-        return ref SetAutoOverride<TFirst, TSecond>(ref component);
-    }
-
-    /// <summary>
-    ///     Set pair, mark component for auto-overriding.
-    /// </summary>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        return ref AutoOverride<TFirst, TSecond>().Set<TFirst, TSecond>(ref component);
-    }
-
-    /// <summary>
-    ///     Set pair, mark component for auto-overriding.
-    /// </summary>
-    /// <param name="second"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        return ref SetAutoOverride<TFirst, TSecond>(second, ref component);
-    }
-
-    /// <summary>
-    ///     Set pair, mark component for auto-overriding.
-    /// </summary>
-    /// <param name="second"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
+    /// <param name="second">The second id (enum member) of the pair.</param>
+    /// <param name="component">The component data.</param>
+    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
+    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
+    /// <returns>Reference to self.</returns>
+    public ref Entity SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
         ulong secondId = Type<TSecond>.Id(World, second);
-        return ref AutoOverride<TFirst>(secondId).Set(secondId, ref component);
+        return ref AutoOverride<TFirst>(secondId).Set(secondId, in component);
     }
 
     /// <summary>
     ///     Set pair, mark component for auto-overriding.
     /// </summary>
-    /// <param name="first"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        return ref SetAutoOverride<TFirst, TSecond>(first, ref component);
-    }
-
-    /// <summary>
-    ///     Set pair, mark component for auto-overriding.
-    /// </summary>
-    /// <param name="first"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TFirst"></typeparam>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
+    /// <param name="first">The first id (enum member) of the pair.</param>
+    /// <param name="component">The component data.</param>
+    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
+    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
+    /// <returns>Reference to self.</returns>
+    public ref Entity SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
         ulong firstId = Type<TFirst>.Id(World, first);
-        return ref AutoOverrideSecond<TSecond>(firstId).SetSecond(firstId, ref component);
+        return ref AutoOverrideSecond<TSecond>(firstId).SetSecond(firstId, in component);
     }
 
     /// <summary>
     ///     Set pair, mark component for auto-overriding.
     /// </summary>
-    /// <param name="first"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
+    /// <param name="first">The first id of the pair.</param>
+    /// <param name="component">The component data.</param>
+    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
+    /// <returns>Reference to self.</returns>
+    public ref Entity SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        return ref SetAutoOverrideSecond(first, ref component);
-    }
-
-    /// <summary>
-    ///     Set pair, mark component for auto-overriding.
-    /// </summary>
-    /// <param name="first"></param>
-    /// <param name="component"></param>
-    /// <typeparam name="TSecond"></typeparam>
-    /// <returns></returns>
-    public ref Entity SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        return ref AutoOverrideSecond<TSecond>(first).SetSecond(first, ref component);
+        return ref AutoOverrideSecond<TSecond>(first).SetSecond(first, in component);
     }
 
     /// <summary>
@@ -2625,171 +2540,86 @@ public unsafe partial struct Entity : IEquatable<Entity>, IEntity<Entity>
     /// <summary>
     ///     Sets the data of a component.
     /// </summary>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="T">The component type.</typeparam>
     /// <returns>Reference to self.</returns>
-    public ref Entity Set<T>(T data)
+    public ref Entity Set<T>(in T data)
     {
-        return ref Set(ref data);
+        return ref SetInternal(Type<T>.Id(World), in data);
     }
 
     /// <summary>
     ///     Sets the data of a pair component.
     /// </summary>
     /// <param name="second">The second id of the pair.</param>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst>(ulong second, TFirst data)
+    public ref Entity Set<TFirst>(ulong second, in TFirst data)
     {
-        return ref Set(second, ref data);
+        return ref SetInternal(Ecs.Pair<TFirst>(second, World), in data);
     }
 
     /// <summary>
     ///     Sets the data of a pair component.
     /// </summary>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(TSecond data)
+    public ref Entity Set<TFirst, TSecond>(in TSecond data)
     {
-        return ref Set<TFirst, TSecond>(ref data);
+        return ref SetInternal(Ecs.Pair<TFirst, TSecond>(World), in data);
     }
 
     /// <summary>
     ///     Sets the data of a pair component.
     /// </summary>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(TFirst data)
+    public ref Entity Set<TFirst, TSecond>(in TFirst data)
     {
-        return ref Set<TFirst, TSecond>(ref data);
+        return ref SetInternal(Ecs.Pair<TFirst, TSecond>(World), in data);
     }
 
     /// <summary>
     ///     Sets the data of a pair component.
     /// </summary>
     /// <param name="second">The second id (enum member) of the pair.</param>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    public ref Entity Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        return ref Set<TFirst, TSecond>(second, ref data);
+        return ref Set(Type<TSecond>.Id(World, second), in data);
     }
 
     /// <summary>
     ///     Sets the data of a pair component.
     /// </summary>
     /// <param name="first">The first id (enum member) of the pair.</param>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    public ref Entity Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        return ref Set<TFirst, TSecond>(first, ref data);
+        return ref SetSecond(Type<TFirst>.Id(World, first), in data);
     }
 
     /// <summary>
     ///     Sets the data of a pair component.
     /// </summary>
     /// <param name="first">The first id of the pair.</param>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public ref Entity SetSecond<TSecond>(ulong first, TSecond data)
+    public ref Entity SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        return ref SetSecond(first, ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a component.
-    /// </summary>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="T">The component type.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public ref Entity Set<T>(ref T data)
-    {
-        return ref SetInternal(Type<T>.Id(World), ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a pair component.
-    /// </summary>
-    /// <param name="second">The second id of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst>(ulong second, ref TFirst data)
-    {
-        return ref SetInternal(Ecs.Pair<TFirst>(second, World), ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a pair component.
-    /// </summary>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(ref TSecond data)
-    {
-        return ref SetInternal(Ecs.Pair<TFirst, TSecond>(World), ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a pair component.
-    /// </summary>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(ref TFirst data)
-    {
-        return ref SetInternal(Ecs.Pair<TFirst, TSecond>(World), ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a pair component.
-    /// </summary>
-    /// <param name="second">The second id (enum member) of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        return ref Set(Type<TSecond>.Id(World, second), ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a pair component.
-    /// </summary>
-    /// <param name="first">The first id (enum member) of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public ref Entity Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        return ref SetSecond(Type<TFirst>.Id(World, first), ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a pair component.
-    /// </summary>
-    /// <param name="first">The first id of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public ref Entity SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        return ref SetInternal(Ecs.PairSecond<TSecond>(first, World), ref data);
+        return ref SetInternal(Ecs.PairSecond<TSecond>(first, World), in data);
     }
 
     /// <summary>
@@ -3677,7 +3507,7 @@ public unsafe partial struct Entity : IEquatable<Entity>, IEntity<Entity>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref Entity SetInternal<T>(ulong id, ref T component)
+    private ref Entity SetInternal<T>(ulong id, in T component)
     {
         fixed (T* ptr = &component)
             return ref SetInternal(id, ptr);

--- a/src/Flecs.NET/Core/IEntity.cs
+++ b/src/Flecs.NET/Core/IEntity.cs
@@ -531,47 +531,26 @@ public unsafe interface IEntity<TEntity> : IId
     /// <inheritdoc cref="Entity.AutoOverrideSecond{TSecond}(ulong)"/>
     public ref TEntity AutoOverrideSecond<TSecond>(ulong first);
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref TEntity SetAutoOverride<T>(T component);
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref TEntity SetAutoOverride<T>(in T component);
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref TEntity SetAutoOverride<T>(ref T component);
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref TEntity SetAutoOverride<TFirst>(ulong second, in TFirst component);
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref TEntity SetAutoOverride<TFirst>(ulong second, TFirst component);
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref TEntity SetAutoOverride<TFirst, TSecond>(in TFirst component);
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref TEntity SetAutoOverride<TFirst>(ulong second, ref TFirst component);
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref TEntity SetAutoOverride<TFirst, TSecond>(in TSecond component);
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(TFirst component);
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref TEntity SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum;
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(ref TFirst component);
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref TEntity SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum;
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(TSecond component);
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(ref TSecond component);
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum;
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum;
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum;
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref TEntity SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum;
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref TEntity SetAutoOverrideSecond<TSecond>(ulong first, TSecond component);
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref TEntity SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component);
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref TEntity SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component);
 
     /// <inheritdoc cref="Entity.Enable()"/>
     public ref TEntity Enable();
@@ -663,47 +642,26 @@ public unsafe interface IEntity<TEntity> : IId
     /// <inheritdoc cref="Entity.SetPtrSecond{TSecond}(ulong, TSecond*)"/>
     public ref TEntity SetPtrSecond<TSecond>(ulong first, TSecond* data);
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref TEntity Set<T>(T data);
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref TEntity Set<T>(in T data);
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref TEntity Set<TFirst>(ulong second, TFirst data);
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref TEntity Set<TFirst>(ulong second, in TFirst data);
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref TEntity Set<TFirst, TSecond>(TSecond data);
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref TEntity Set<TFirst, TSecond>(in TSecond data);
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref TEntity Set<TFirst, TSecond>(TFirst data);
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref TEntity Set<TFirst, TSecond>(in TFirst data);
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref TEntity Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum;
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref TEntity Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum;
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref TEntity Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum;
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref TEntity Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum;
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref TEntity SetSecond<TSecond>(ulong first, TSecond data);
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref TEntity Set<T>(ref T data);
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref TEntity Set<TFirst>(ulong second, ref TFirst data);
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref TEntity Set<TFirst, TSecond>(ref TSecond data);
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref TEntity Set<TFirst, TSecond>(ref TFirst data);
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref TEntity Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum;
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref TEntity Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum;
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref TEntity SetSecond<TSecond>(ulong first, ref TSecond data);
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref TEntity SetSecond<TSecond>(ulong first, in TSecond data);
 
     /// <inheritdoc cref="Entity.With(Action)"/>
     public ref TEntity With(Action callback);

--- a/src/Flecs.NET/Core/World.cs
+++ b/src/Flecs.NET/Core/World.cs
@@ -566,97 +566,12 @@ public readonly unsafe partial struct World : IDisposable, IEquatable<World>
     /// <summary>
     ///     Sets the data of a singleton component.
     /// </summary>
-    /// <param name="data">The data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="T">The component type.</typeparam>
     /// <returns>Reference to self.</returns>
-    public World Set<T>(T data)
+    public World Set<T>(in T data)
     {
-        return Set(ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a singleton pair component.
-    /// </summary>
-    /// <param name="second">The second id of the pair.</param>
-    /// <param name="data">The data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public World Set<TFirst>(ulong second, TFirst data)
-    {
-        return Set(second, ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a singleton pair component.
-    /// </summary>
-    /// <param name="data">The data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(TFirst data)
-    {
-        return Set<TFirst, TSecond>(ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a singleton pair component.
-    /// </summary>
-    /// <param name="data">The data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(TSecond data)
-    {
-        return Set<TFirst, TSecond>(ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a singleton pair component.
-    /// </summary>
-    /// <param name="second">The second id (enum member) of the pair.</param>
-    /// <param name="data">The data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
-    {
-        return Set<TFirst, TSecond>(second, ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a singleton pair component.
-    /// </summary>
-    /// <param name="first">The first id (enum member) of the pair.</param>
-    /// <param name="data">The data.</param>
-    /// <typeparam name="TFirst">The first type of the pair.</typeparam>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
-    {
-        return Set<TFirst, TSecond>(first, ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a singleton pair component.
-    /// </summary>
-    /// <param name="first">The first id of the pair</param>
-    /// <param name="data">The data.</param>
-    /// <typeparam name="TSecond">The second type of the pair.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public World SetSecond<TSecond>(ulong first, TSecond data)
-    {
-        return SetSecond(first, ref data);
-    }
-
-    /// <summary>
-    ///     Sets the data of a singleton component.
-    /// </summary>
-    /// <param name="data">The reference to the data.</param>
-    /// <typeparam name="T">The component type.</typeparam>
-    /// <returns>Reference to self.</returns>
-    public World Set<T>(ref T data)
-    {
-        Entity<T>().Set(ref data);
+        Entity<T>().Set(in data);
         return this;
     }
 
@@ -664,38 +579,38 @@ public readonly unsafe partial struct World : IDisposable, IEquatable<World>
     ///     Sets the data of a singleton pair component.
     /// </summary>
     /// <param name="second">The second id of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public World Set<TFirst>(ulong second, ref TFirst data)
+    public World Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity<TFirst>().Set(second, ref data);
+        Entity<TFirst>().Set(second, in data);
         return this;
     }
 
     /// <summary>
     ///     Sets the data of a singleton pair component.
     /// </summary>
-    /// <param name="data">The reference to the data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(ref TFirst data)
+    public World Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity<TFirst>().Set<TFirst, TSecond>(ref data);
+        Entity<TFirst>().Set<TFirst, TSecond>(in data);
         return this;
     }
 
     /// <summary>
     ///     Sets the data of a singleton pair component.
     /// </summary>
-    /// <param name="data">The reference to the data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(ref TSecond data)
+    public World Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity<TFirst>().Set<TFirst, TSecond>(ref data);
+        Entity<TFirst>().Set<TFirst, TSecond>(in data);
         return this;
     }
 
@@ -703,38 +618,38 @@ public readonly unsafe partial struct World : IDisposable, IEquatable<World>
     ///     Sets the data of a singleton pair component.
     /// </summary>
     /// <param name="second">The second id (enum member) of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
+    public World Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        return Set(Type<TSecond>.Id(Handle, second), ref data);
+        return Set(Type<TSecond>.Id(Handle, second), in data);
     }
 
     /// <summary>
     ///     Sets the data of a singleton pair component.
     /// </summary>
     /// <param name="first">The first id (enum member) of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TFirst">The first type of the pair.</typeparam>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public World Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
+    public World Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        return SetSecond(Type<TFirst>.Id(Handle, first), ref data);
+        return SetSecond(Type<TFirst>.Id(Handle, first), in data);
     }
 
     /// <summary>
     ///     Sets the data of a singleton pair component.
     /// </summary>
     /// <param name="first">The first id of the pair.</param>
-    /// <param name="data">The reference to the data.</param>
+    /// <param name="data">The component data.</param>
     /// <typeparam name="TSecond">The second type of the pair.</typeparam>
     /// <returns>Reference to self.</returns>
-    public World SetSecond<TSecond>(ulong first, ref TSecond data)
+    public World SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity(first).SetSecond(first, ref data);
+        Entity(first).SetSecond(first, in data);
         return this;
     }
 

--- a/src/Flecs.NET/Generated/Alert/Alert.Entity.g.cs
+++ b/src/Flecs.NET/Generated/Alert/Alert.Entity.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Alert
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Alert SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Alert SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Alert SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Alert SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Alert SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Alert SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Alert SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Alert SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Alert SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Alert SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Alert SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Alert SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Alert SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Alert SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Alert
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Alert Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Alert Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Alert Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Alert Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Alert Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Alert Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Alert Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Alert Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Alert Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Alert Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Alert Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Alert Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Alert SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Alert SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Alert Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Alert Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Alert Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Alert Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Alert Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Alert Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Alert SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Component/Component.Entity.g.cs
+++ b/src/Flecs.NET/Generated/Component/Component.Entity.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Component<TComponent>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Component<TComponent> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Component<TComponent> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Component<TComponent> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Component<TComponent> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Component<TComponent> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Component<TComponent> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Component<TComponent> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Component<TComponent> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Component<TComponent>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Component<TComponent> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Component<TComponent> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Component<TComponent> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Component<TComponent> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Component<TComponent> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Component<TComponent> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Component<TComponent> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Component<TComponent> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Component<TComponent> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Component<TComponent> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Component<TComponent> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Component<TComponent> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Component<TComponent> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Component<TComponent> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T1.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T1.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T10.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T10.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T11.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T11.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T12.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T12.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T13.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T13.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T14.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T14.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T15.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T15.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T16.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T16.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T2.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T2.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T3.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T3.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T4.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T4.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T5.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T5.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T6.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T6.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T7.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T7.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T8.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T8.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Observer/Observer.Entity/T9.g.cs
+++ b/src/Flecs.NET/Generated/Observer/Observer.Entity/T9.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Observer<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T1.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T1.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T10.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T10.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T11.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T11.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T12.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T12.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T13.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T13.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T14.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T14.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T15.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T15.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T16.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T16.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T1
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T2.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T2.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T3.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T3.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T4.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T4.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T5.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T5.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T6.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T6.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T7.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T7.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T8.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T8.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T9.g.cs
+++ b/src/Flecs.NET/Generated/Pipeline/Pipeline.Entity/T9.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref Pipeline<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System_
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System_ SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System_ SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System_ SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System_ SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System_ SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System_ SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System_ SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System_ SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System_ SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System_ SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System_ SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System_ SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System_ SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System_ SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System_
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System_ Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System_ Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System_ Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System_ Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System_ Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System_ Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System_ Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System_ Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System_ Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System_ Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System_ Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System_ Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System_ SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System_ SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System_ Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System_ Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System_ Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System_ Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System_ Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System_ Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System_ SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T1.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T1.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T10.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T10.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T11.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T11.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T12.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T12.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T13.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T13.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T14.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T14.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T15.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T15.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T16.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T16.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T2.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T2.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T3.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T3.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T4.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T4.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T5.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T5.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T6.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T6.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T7.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T7.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T8.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T8.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/System_/System.Entity/T9.g.cs
+++ b/src/Flecs.NET/Generated/System_/System.Entity/T9.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct System<T0, T1, T2, T3, T4, T5, T6, T7, T8>
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref System<T0, T1, T2, T3, T4, T5, T6, T7, T8> SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/TimerEntity/TimerEntity.Entity.g.cs
+++ b/src/Flecs.NET/Generated/TimerEntity/TimerEntity.Entity.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct TimerEntity
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref TimerEntity SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref TimerEntity SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref TimerEntity SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref TimerEntity SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref TimerEntity SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref TimerEntity SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref TimerEntity SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref TimerEntity SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref TimerEntity SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref TimerEntity SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct TimerEntity
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref TimerEntity Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref TimerEntity Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref TimerEntity Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref TimerEntity Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref TimerEntity Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref TimerEntity Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref TimerEntity Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref TimerEntity Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref TimerEntity SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref TimerEntity SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref TimerEntity Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref TimerEntity Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref TimerEntity Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref TimerEntity SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 

--- a/src/Flecs.NET/Generated/UntypedComponent/UntypedComponent.Entity.g.cs
+++ b/src/Flecs.NET/Generated/UntypedComponent/UntypedComponent.Entity.g.cs
@@ -1092,101 +1092,52 @@ public unsafe partial struct UntypedComponent
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(T)"/>
-    public ref UntypedComponent SetAutoOverride<T>(T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{T}(in T)"/>
+    public ref UntypedComponent SetAutoOverride<T>(in T component)
     {
-        Entity.SetAutoOverride(component);
+        Entity.SetAutoOverride(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{T}(ref T)"/>
-    public ref UntypedComponent SetAutoOverride<T>(ref T component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, in TFirst)"/>
+    public ref UntypedComponent SetAutoOverride<TFirst>(ulong second, in TFirst component)
     {
-        Entity.SetAutoOverride(ref component);
+        Entity.SetAutoOverride(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, TFirst)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst>(ulong second, TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TFirst)"/>
+    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(in TFirst component)
     {
-        Entity.SetAutoOverride(second, component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst}(ulong, ref TFirst)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst>(ulong second, ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(in TSecond)"/>
+    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(in TSecond component)
     {
-        Entity.SetAutoOverride(second, ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TSecond second, in TFirst component) where TSecond : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
+        Entity.SetAutoOverride<TFirst, TSecond>(second, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TFirst)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(ref TFirst component)
+    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TFirst first, in TSecond component) where TFirst : Enum
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
+        Entity.SetAutoOverride<TFirst, TSecond>(first, in component);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TSecond component)
+    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, in TSecond)"/>
+    public ref UntypedComponent SetAutoOverrideSecond<TSecond>(ulong first, in TSecond component)
     {
-        Entity.SetAutoOverride<TFirst, TSecond>(component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(ref TSecond)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(ref TSecond component)
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TSecond second, TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TSecond second, ref TFirst component) where TSecond : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(second, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TFirst first, TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverride{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref UntypedComponent SetAutoOverride<TFirst, TSecond>(TFirst first, ref TSecond component) where TFirst : Enum
-    {
-        Entity.SetAutoOverride<TFirst, TSecond>(first, ref component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, TSecond)"/>
-    public ref UntypedComponent SetAutoOverrideSecond<TSecond>(ulong first, TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, component);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetAutoOverrideSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref UntypedComponent SetAutoOverrideSecond<TSecond>(ulong first, ref TSecond component)
-    {
-        Entity.SetAutoOverrideSecond(first, ref component);
+        Entity.SetAutoOverrideSecond(first, in component);
         return ref this;
     }
 
@@ -1400,101 +1351,52 @@ public unsafe partial struct UntypedComponent
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{T}(T)"/>
-    public ref UntypedComponent Set<T>(T data)
+    /// <inheritdoc cref="Entity.Set{T}(in T)"/>
+    public ref UntypedComponent Set<T>(in T data)
     {
-        Entity.Set(data);
+        Entity.Set(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, TFirst)"/>
-    public ref UntypedComponent Set<TFirst>(ulong second, TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, in TFirst)"/>
+    public ref UntypedComponent Set<TFirst>(ulong second, in TFirst data)
     {
-        Entity.Set(second, data);
+        Entity.Set(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(TSecond data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TSecond)"/>
+    public ref UntypedComponent Set<TFirst, TSecond>(in TSecond data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(TFirst data)
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(in TFirst)"/>
+    public ref UntypedComponent Set<TFirst, TSecond>(in TFirst data)
     {
-        Entity.Set<TFirst, TSecond>(data);
+        Entity.Set<TFirst, TSecond>(in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, TFirst)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(TSecond second, TFirst data) where TSecond : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, in TFirst)"/>
+    public ref UntypedComponent Set<TFirst, TSecond>(TSecond second, in TFirst data) where TSecond : Enum
     {
-        Entity.Set<TFirst, TSecond>(second, data);
+        Entity.Set<TFirst, TSecond>(second, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, TSecond)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(TFirst first, TSecond data) where TFirst : Enum
+    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, in TSecond)"/>
+    public ref UntypedComponent Set<TFirst, TSecond>(TFirst first, in TSecond data) where TFirst : Enum
     {
-        Entity.Set<TFirst, TSecond>(first, data);
+        Entity.Set<TFirst, TSecond>(first, in data);
         return ref this;
     }
 
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, TSecond)"/>
-    public ref UntypedComponent SetSecond<TSecond>(ulong first, TSecond data)
+    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, in TSecond)"/>
+    public ref UntypedComponent SetSecond<TSecond>(ulong first, in TSecond data)
     {
-        Entity.SetSecond(first, data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{T}(ref T)"/>
-    public ref UntypedComponent Set<T>(ref T data)
-    {
-        Entity.Set(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst}(ulong, ref TFirst)"/>
-    public ref UntypedComponent Set<TFirst>(ulong second, ref TFirst data)
-    {
-        Entity.Set(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TSecond)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(ref TSecond data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(ref TFirst)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(ref TFirst data)
-    {
-        Entity.Set<TFirst, TSecond>(ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TSecond, ref TFirst)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(TSecond second, ref TFirst data) where TSecond : Enum
-    {
-        Entity.Set<TFirst, TSecond>(second, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.Set{TFirst, TSecond}(TFirst, ref TSecond)"/>
-    public ref UntypedComponent Set<TFirst, TSecond>(TFirst first, ref TSecond data) where TFirst : Enum
-    {
-        Entity.Set<TFirst, TSecond>(first, ref data);
-        return ref this;
-    }
-
-    /// <inheritdoc cref="Entity.SetSecond{TSecond}(ulong, ref TSecond)"/>
-    public ref UntypedComponent SetSecond<TSecond>(ulong first, ref TSecond data)
-    {
-        Entity.SetSecond(first, ref data);
+        Entity.SetSecond(first, in data);
         return ref this;
     }
 


### PR DESCRIPTION
All ``.Set()`` and ``.SetAutoOverride()`` overloads have been changed to use the ``in`` parameter modifier to pass in component data.

Below are all valid ways of setting components.
```cs
Position position = new Position(1, 2);

Entity entity = world.Entity();
entity.Set(position);     // Pass by value.
entity.Set(in position);  // Pass by in reference.
entity.Set(ref position); // Pass by ref reference but a warning is issued.
```